### PR TITLE
fix(BidHistory): display connected user's anonymous id

### DIFF
--- a/.changeset/new-pugs-clap.md
+++ b/.changeset/new-pugs-clap.md
@@ -1,0 +1,5 @@
+---
+"@encheres-immo/auction-widget": patch
+---
+
+fix the connected user name when he has already bid

--- a/.changeset/new-pugs-clap.md
+++ b/.changeset/new-pugs-clap.md
@@ -2,4 +2,4 @@
 "@encheres-immo/auction-widget": patch
 ---
 
-fix the connected user name when he has already bid
+Fixed an issue where the connected user's bids showed their anonymous ID instead of 'You'.

--- a/packages/auction-widget/src/App.tsx
+++ b/packages/auction-widget/src/App.tsx
@@ -129,7 +129,7 @@ const App: Component<{
           isLogged={isLogged}
           setIsLogged={setIsLogged}
           isLogging={isLogging}
-          updateUser={updateUser(user(), propertyInfo)}
+          updateUser={updateUser}
           allowUserRegistration={allowUserRegistration}
           tosUrl={tosUrl}
         />


### PR DESCRIPTION
## What does this change?

When the connected user has bid on an auction, it's anonymous id were shown, instead of "Vous" / "You"

Before:
![Capture d’écran 2024-12-30 à 16 13 58](https://github.com/user-attachments/assets/676e45d5-07d1-4265-a7f4-c1dcc1af2aa8)

After:
![Capture d’écran 2024-12-30 à 16 12 18](https://github.com/user-attachments/assets/e955d8c4-3200-43a0-a664-e5486599a525)

## How is it tested?

Locally

## How is it documented?

Bug fixing, not needed.