### PR TITLE
Fix modal stacking order

### DIFF
--- a/packages/auction-widget/assets/app.css
+++ b/packages/auction-widget/assets/app.css
@@ -20,6 +20,7 @@
     transition-property: opacity;
     transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
     transition-duration: 300ms;
+    z-index: 40;
   }
 
   #auction-widget-box {


### PR DESCRIPTION
Fixes #39

Add `z-index: 40;` to `#auction-widget-modal-background` in `packages/auction-widget/assets/app.css`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/encheres-immo/auction-widget/pull/40?shareId=660a909f-8bb9-4e8a-80b8-5a6372327ca5).