### PR TITLE
fix(icons): drop font awesome for svg spritesheet

### DIFF
--- a/.changeset/strong-spiders-cry.md
+++ b/.changeset/strong-spiders-cry.md
@@ -1,0 +1,5 @@
+---
+"@encheres-immo/auction-widget": patch
+---
+
+Fixed SVG icons not being displayed properly in the widget. A Font Awesome kit is no longer required.

--- a/example/src/pages/index.astro
+++ b/example/src/pages/index.astro
@@ -23,10 +23,6 @@ import {
       tos-url={TOS_URL}
     >
     </div>
-    <link
-      rel="stylesheet"
-      href="http://localhost:4000/webfonts/font-awesome.min.css"
-    />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link

--- a/packages/auction-widget/README.md
+++ b/packages/auction-widget/README.md
@@ -146,8 +146,9 @@ This widget is maintained by the [Enchères Immo](https://encheres-immo.com/) te
 
 All commands are run from the root of the package.
 
-| Command          | Description          |
-| ---------------- | -------------------- |
-| `pnpm install`   | Install dependencies |
-| `pnpm run build` | Build the widget     |
-| `pnpm run test`  | Run tests            |
+| Command                  | Description                            |
+| ------------------------ | -------------------------------------- |
+| `pnpm install`           | Install dependencies                   |
+| `pnpm run build`         | Build the widget (minified)            |
+| `pnpm run build --watch` | Build the widget and watch for changes |
+| `pnpm run test`          | Run tests                              |

--- a/packages/auction-widget/assets/app.css
+++ b/packages/auction-widget/assets/app.css
@@ -1,5 +1,22 @@
-@layer auction-widget, auction-widget-override;
+@layer auction-widget-base, auction-widget, auction-widget-override;
 
+/* 
+  #region Auction Widget
+  Limit CSS interferences with host page with a basic reset.
+  Heritance of certain properties can be desired (e.g. font-family).
+*/
+@layer auction-widget-base {
+  #auction-widget-box svg {
+    display: inline-block;
+    height: 1.25rem;
+    width: 1.25rem;
+  }
+
+  /* TODO: add reset here */
+}
+
+/* #region Auction Widget */
+/* Style for elements and components of the Auction Widget */
 @layer auction-widget {
   :root {
     --auction-widget-highlight-color: #ef673d;
@@ -317,6 +334,11 @@
     background-color: var(--auction-widget-dark-color);
     color: white;
     cursor: default;
+  }
+
+  .auction-widget-user-icon {
+    height: 0.75rem;
+    width: 0.75rem;
   }
 
   #auction-widget-bid-amount {

--- a/packages/auction-widget/esbuild.config.mjs
+++ b/packages/auction-widget/esbuild.config.mjs
@@ -1,10 +1,32 @@
-import { build } from "esbuild";
+import esbuild from "esbuild";
 import { solidPlugin } from "esbuild-plugin-solid";
 
-build({
-  entryPoints: ["src/index.tsx"],
-  bundle: true,
-  outfile: "dist/auction-widget.js",
-  plugins: [solidPlugin()],
-  minify: true,
-}).catch(() => process.exit(1));
+async function build() {
+  const isDev = process.argv.includes("--watch");
+
+  const config = {
+    entryPoints: ["src/index.tsx"],
+    bundle: true,
+    outfile: "dist/auction-widget.js",
+    plugins: [solidPlugin()],
+  };
+
+  if (!isDev) {
+    await esbuild.build({
+      ...config,
+      minify: true,
+    });
+
+    return;
+  }
+
+  const builder = await esbuild.context({ ...config, minify: false });
+
+  await builder.watch();
+
+  process.on("beforeExit", () => {
+    builder.dispose && builder.dispose();
+  });
+}
+
+await build();

--- a/packages/auction-widget/src/App.tsx
+++ b/packages/auction-widget/src/App.tsx
@@ -15,6 +15,7 @@ import {
   UserType,
   PropertyInfoType,
 } from "@encheres-immo/widget-client/types";
+import { Spritesheet } from "./Spritesheet.jsx";
 
 const [isLogged, setIsLogged] = createSignal(false);
 const [isLogging, setIsLogging] = createSignal(false);
@@ -80,7 +81,7 @@ function refreshAuction(propertyInfo: PropertyInfoType) {
           endDate: newEndDate,
         });
       })
-      .catch((err) => {
+      .catch((err: any) => {
         console.error("Error subscribing to auction:", err);
       });
   });
@@ -148,6 +149,7 @@ const App: Component<{
         <BidForm auction={auction} isLogged={isLogged} />
         <BidHistory bids={bids} auction={auction} user={user()} />
       </Show>
+      <Spritesheet />
     </div>
   );
 };

--- a/packages/auction-widget/src/BidForm.tsx
+++ b/packages/auction-widget/src/BidForm.tsx
@@ -191,11 +191,7 @@ const BidForm: Component<{
           </div>
         </div>
         <Show when={isConfirmBidOpen()}>
-          <CenteredModal
-            title="Vous êtes sur le point d'enchérir"
-            success={false}
-            icon_class="fas fa-gavel"
-          >
+          <CenteredModal title="Vous êtes sur le point d'enchérir" icon="gavel">
             <table id="auction-widget-table">
               <tbody>
                 <Show when={props.auction.highestBid.participantId}>

--- a/packages/auction-widget/src/BidHistory.tsx
+++ b/packages/auction-widget/src/BidHistory.tsx
@@ -11,6 +11,7 @@ import {
   isAuctionInProgress,
   formatDate,
 } from "./utils.js";
+import { Icon } from "./Spritesheet.jsx";
 
 /**
  * Display every bid made on an auction.
@@ -44,14 +45,17 @@ const BidHistory: Component<{
               {(bid, i) => (
                 <li>
                   <Show
-                    when={bid.participantId === props.user.id}
+                    when={props.user && bid.participantId === props.user.id}
                     fallback={
                       <div>
                         <p class="auction-widget-date">
                           Le {formatDate(bid.createdAt)}
                         </p>
                         <span class="auction-widget-user">
-                          <i class="fas fa-user"></i>
+                          <Icon
+                            name="user"
+                            svgClass="auction-widget-user-icon"
+                          />
                           {bid.userAnonymousId}
                         </span>
                         a enchéri
@@ -63,7 +67,8 @@ const BidHistory: Component<{
                         Le {formatDate(bid.createdAt)}
                       </p>
                       <span class="auction-widget-user">
-                        <i class="fas fa-user"></i>Vous
+                        <Icon name="user" svgClass="auction-widget-user-icon" />
+                        Vous
                       </span>
                       avez enchéri
                     </div>

--- a/packages/auction-widget/src/CenteredModal.tsx
+++ b/packages/auction-widget/src/CenteredModal.tsx
@@ -1,9 +1,13 @@
-import { Show, type Component, JSXElement } from "solid-js";
+import { type Component, JSXElement } from "solid-js";
+import { Icon, Icons } from "./Spritesheet.jsx";
+
+/**
+ * A centered modal to display a message to the user.
+ */
 const CenteredModal: Component<{
   children: JSXElement;
-  success: boolean | void;
-  icon_class: string | void;
-  title: string | void;
+  title: string;
+  icon: Icons;
 }> = (props: any) => {
   return (
     <div>
@@ -11,23 +15,10 @@ const CenteredModal: Component<{
 
       <div class="auction-widget-modal">
         <div id="auction-widget-modal-content">
+          <Icon name={props.icon} parentClass="auction-widget-icon" />
           <div>
-            <Show when={props.success}>
-              <div class="auction-widget-icon">
-                <i class="fas fa-check" />
-              </div>
-            </Show>
-            <Show when={props.icon_class}>
-              <div class="auction-widget-icon">
-                <i class={props.icon_class} />
-              </div>
-            </Show>
-            <div>
-              <Show when={props.title}>
-                <h3>{props.title}</h3>
-              </Show>
-              <div>{props.children}</div>
-            </div>
+            <h3>{props.title}</h3>
+            <div>{props.children}</div>
           </div>
         </div>
       </div>

--- a/packages/auction-widget/src/ParticipateBox.tsx
+++ b/packages/auction-widget/src/ParticipateBox.tsx
@@ -7,6 +7,7 @@ import {
   UserType,
 } from "@encheres-immo/widget-client/types";
 import CenteredModal from "./CenteredModal.js";
+import { Icon } from "./Spritesheet.jsx";
 
 /**
  * Render the participate button, and different modals allowing the user to connect, register to the auction,
@@ -31,7 +32,7 @@ const ParticipateBox: Component<{
    * Try to connect the user to the API and retrieve its informations.
    */
   function tryToConnect() {
-    client.authenticate().then(() => {
+    (client.authenticate() as Promise<void>).then(() => {
       client.me().then((user) => {
         if (user) {
           props.updateUser(user, props.propertyInfo);
@@ -75,11 +76,7 @@ const ParticipateBox: Component<{
       </div>
 
       <Show when={isModalOpen() && !props.isLogged()}>
-        <CenteredModal
-          title="Vous devez être connecté"
-          icon_class="fas fa-user-lock"
-          success={false}
-        >
+        <CenteredModal title="Vous devez être connecté" icon="user-lock">
           <div class="auction-widget-action">
             <button
               class="auction-widget-btn auction-widget-custom"
@@ -120,11 +117,7 @@ const ParticipateBox: Component<{
           props.allowUserRegistration
         }
       >
-        <CenteredModal
-          title="Demande de participation"
-          success={false}
-          icon_class="fas fa-gavel"
-        >
+        <CenteredModal title="Demande de participation" icon="gavel">
           En cliquant sur Valider, je reconnais avoir lu et accepté{" "}
           <a
             href={
@@ -166,24 +159,20 @@ const ParticipateBox: Component<{
           isContactModalOpen()
         }
       >
-        <CenteredModal
-          title="Demande de participation"
-          icon_class="fas fa-gavel"
-          success={false}
-        >
+        <CenteredModal title="Demande de participation" icon="gavel">
           <div class="auction-widget-contact">
             <a
               href={"mailto:" + props.auction.agentEmail}
               class="auction-widget-btn auction-widget-custom"
             >
-              <i class="fas fa-envelope"></i>
+              <Icon name="envelope" />
               {props.auction.agentEmail}
             </a>
             <a
               href={"tel:" + props.auction.agentPhone}
               class="auction-widget-btn auction-widget-custom"
             >
-              <i class="fas fa-phone"></i>
+              <Icon name="phone" />
               {props.auction.agentPhone}
             </a>
           </div>

--- a/packages/auction-widget/src/Spritesheet.tsx
+++ b/packages/auction-widget/src/Spritesheet.tsx
@@ -1,0 +1,90 @@
+import type { Component } from "solid-js";
+
+/**
+ * List of available icons in the Spritesheet component.
+ */
+export type Icons =
+  | "check"
+  | "envelope"
+  | "gavel"
+  | "phone"
+  | "user"
+  | "user-lock";
+
+/**
+ * Icon component to display an SVG icon from the Spritesheet.
+ * Reference: https://developer.mozilla.org/en-US/docs/Web/SVG/Element/use
+ */
+export const Icon = (props: {
+  name: Icons;
+  parentClass?: string;
+  svgClass?: string;
+}) => {
+  return (
+    <div class={`${props.parentClass}`}>
+      <svg class={props.svgClass}>
+        <use href={`#${props.name}`} />
+      </svg>
+    </div>
+  );
+};
+
+/**
+ * A hidden SVG spritesheet, used to avoid loading the same SVG multiple times.
+ * For usage, see the Icon component.
+ * Reference: https://developer.mozilla.org/en-US/docs/Web/SVG/Element/symbol
+ *
+ * ## Find new icons
+ * Go to -> https://icones.js.org/
+ * Filter for Font Awesome 6 collections (Solid is preferred)
+ * Click on the icon you want to use and then copy « SVG Symbol »
+ * Paste the symbol in the Spritesheet component, and update the id with the icon name.
+ * Add the icon name to the Icons type above.
+ */
+export const Spritesheet: Component = (props) => {
+  return (
+    <svg style="position: absolute; width: 0; height: 0; overflow: hidden;">
+      <symbol viewBox="0 0 448 512" id="check">
+        <path
+          fill="currentColor"
+          d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7l233.4-233.3c12.5-12.5 32.8-12.5 45.3 0z"
+        ></path>
+      </symbol>
+
+      <symbol viewBox="0 0 512 512" id="envelope">
+        <path
+          fill="currentColor"
+          d="M48 64C21.5 64 0 85.5 0 112c0 15.1 7.1 29.3 19.2 38.4l217.6 163.2c11.4 8.5 27 8.5 38.4 0l217.6-163.2c12.1-9.1 19.2-23.3 19.2-38.4c0-26.5-21.5-48-48-48zM0 176v208c0 35.3 28.7 64 64 64h384c35.3 0 64-28.7 64-64V176L294.4 339.2a63.9 63.9 0 0 1-76.8 0z"
+        ></path>
+      </symbol>
+
+      <symbol viewBox="0 0 512 512" id="gavel">
+        <path
+          fill="currentColor"
+          d="M318.6 9.4c-12.5-12.5-32.8-12.5-45.3 0l-120 120c-12.5 12.5-12.5 32.8 0 45.3l16 16c12.5 12.5 32.8 12.5 45.3 0l4-4l106.8 106.7l-4 4c-12.5 12.5-12.5 32.8 0 45.3l16 16c12.5 12.5 32.8 12.5 45.3 0l120-120c12.5-12.5 12.5-32.8 0-45.3l-16-16c-12.5-12.5-32.8-12.5-45.3 0l-4 4L330.6 74.6l4-4c12.5-12.5 12.5-32.8 0-45.3l-16-16zm-152 288c-12.5-12.5-32.8-12.5-45.3 0l-112 112c-12.5 12.5-12.5 32.8 0 45.3l48 48c12.5 12.5 32.8 12.5 45.3 0l112-112c12.5-12.5 12.5-32.8 0-45.3l-1.4-1.4l58.8-58.7l-45.3-45.3l-58.7 58.7l-1.4-1.4z"
+        ></path>
+      </symbol>
+
+      <symbol viewBox="0 0 512 512" id="phone">
+        <path
+          fill="currentColor"
+          d="M164.9 24.6c-7.7-18.6-28-28.5-47.4-23.2l-88 24C12.1 30.2 0 46 0 64c0 247.4 200.6 448 448 448c18 0 33.8-12.1 38.6-29.5l24-88c5.3-19.4-4.6-39.7-23.2-47.4l-96-40c-16.3-6.8-35.2-2.1-46.3 11.6L304.7 368c-70.4-33.3-127.4-90.3-160.7-160.7l49.3-40.3c13.7-11.2 18.4-30 11.6-46.3l-40-96z"
+        ></path>
+      </symbol>
+
+      <symbol viewBox="0 0 448 512" id="user">
+        <path
+          fill="currentColor"
+          d="M224 256a128 128 0 1 0 0-256a128 128 0 1 0 0 256m-45.7 48C79.8 304 0 383.8 0 482.3C0 498.7 13.3 512 29.7 512h388.6c16.4 0 29.7-13.3 29.7-29.7c0-98.5-79.8-178.3-178.3-178.3z"
+        ></path>
+      </symbol>
+
+      <symbol viewBox="0 0 640 512" id="user-lock">
+        <path
+          fill="currentColor"
+          d="M224 256a128 128 0 1 0 0-256a128 128 0 1 0 0 256m-45.7 48C79.8 304 0 383.8 0 482.3C0 498.7 13.3 512 29.7 512h362.8c-5.4-9.4-8.6-20.3-8.6-32V352q0-3.15.3-6.3c-31-26-71-41.7-114.6-41.7h-91.4zM528 240c17.7 0 32 14.3 32 32v48h-64v-48c0-17.7 14.3-32 32-32m-80 32v48c-17.7 0-32 14.3-32 32v128c0 17.7 14.3 32 32 32h160c17.7 0 32-14.3 32-32V352c0-17.7-14.3-32-32-32v-48c0-44.2-35.8-80-80-80s-80 35.8-80 80"
+        ></path>
+      </symbol>
+    </svg>
+  );
+};


### PR DESCRIPTION
fixes #38

Fixed SVG icons not being displayed properly in the widget. A Font Awesome kit is no longer required. Also add a `build --watch` option for `auction-widget`.
