### PR TITLE
feat(style): reset for host page and browsers

### DIFF
--- a/.changeset/green-files-hammer.md
+++ b/.changeset/green-files-hammer.md
@@ -1,0 +1,5 @@
+---
+"@encheres-immo/auction-widget": minor
+---
+
+Added CSS reset to isolate widget styles from host page and ensure consistency across browsers. This change *may cause minor visual changes* as fewer styles are inherited from the host page.

--- a/packages/auction-widget/assets/app.css
+++ b/packages/auction-widget/assets/app.css
@@ -441,29 +441,29 @@
   1. Prevent padding and border from affecting element width. (https://github.com/mozdevs/cssremedy/issues/4)
   2. Allow adding a border to an element by just adding a border-width. (https://github.com/tailwindcss/tailwindcss/pull/116)
   */
-  *,
-  ::before,
-  ::after {
+  #auction-widget-box *,
+  #auction-widget-box ::before,
+  #auction-widget-box ::after {
     box-sizing: border-box; /* 1 */
     border-width: 0; /* 2 */
     border-style: solid; /* 2 */
     border-color: theme("borderColor.DEFAULT", currentColor); /* 2 */
   }
 
-  ::before,
-  ::after {
+  #auction-widget-box ::before,
+  #auction-widget-box ::after {
     --tw-content: "";
   }
 
   /*
   Remove the default font size and weight for headings.
   */
-  h1,
-  h2,
-  h3,
-  h4,
-  h5,
-  h6 {
+  #auction-widget-box h1,
+  #auction-widget-box h2,
+  #auction-widget-box h3,
+  #auction-widget-box h4,
+  #auction-widget-box h5,
+  #auction-widget-box h6 {
     font-size: inherit;
     font-weight: inherit;
   }
@@ -471,7 +471,7 @@
   /*
   Reset links to optimize for opt-in styling instead of opt-out.
   */
-  a {
+  #auction-widget-box a {
     color: inherit;
     text-decoration: inherit;
   }
@@ -479,8 +479,8 @@
   /*
   Add the correct font weight in Edge and Safari.
   */
-  b,
-  strong {
+  #auction-widget-box b,
+  #auction-widget-box strong {
     font-weight: bolder;
   }
 
@@ -489,10 +489,10 @@
   2. Remove the margin in Firefox and Safari.
   3. Remove default padding in all browsers.
   */
-  button,
-  input,
-  select,
-  textarea {
+  #auction-widget-box button,
+  #auction-widget-box input,
+  #auction-widget-box select,
+  #auction-widget-box textarea {
     font-family: inherit; /* 1 */
     font-feature-settings: inherit; /* 1 */
     font-variation-settings: inherit; /* 1 */
@@ -506,8 +506,8 @@
   }
 
   /* Remove the inheritance of text transform in Edge and Firefox. */
-  button,
-  select {
+  #auction-widget-box button,
+  #auction-widget-box select {
     text-transform: none;
   }
 
@@ -515,52 +515,52 @@
   1. Correct the inability to style clickable types in iOS and Safari.
   2. Remove default button styles.
   */
-  button,
-  input:where([type="button"]),
-  input:where([type="reset"]),
-  input:where([type="submit"]) {
+  #auction-widget-box button,
+  #auction-widget-box input:where([type="button"]),
+  #auction-widget-box input:where([type="reset"]),
+  #auction-widget-box input:where([type="submit"]) {
     -webkit-appearance: button; /* 1 */
     background-color: transparent; /* 2 */
     background-image: none; /* 2 */
   }
 
   /* Use the modern Firefox focus style for all focusable elements. */
-  :-moz-focusring {
+  #auction-widget-box :-moz-focusring {
     outline: auto;
   }
 
   /* Remove the additional `:invalid` styles in Firefox. (https://github.com/mozilla/gecko-dev/blob/2f9eacd9d3d995c937b4251a5557d95d494c9be1/layout/style/res/forms.css#L728-L737) */
-  :-moz-ui-invalid {
+  #auction-widget-box :-moz-ui-invalid {
     box-shadow: none;
   }
 
   /* Removes the default spacing and border for appropriate elements. */
-  blockquote,
-  dl,
-  dd,
-  h1,
-  h2,
-  h3,
-  h4,
-  h5,
-  h6,
-  hr,
-  figure,
-  p,
-  pre {
+  #auction-widget-box blockquote,
+  #auction-widget-box dl,
+  #auction-widget-box dd,
+  #auction-widget-box h1,
+  #auction-widget-box h2,
+  #auction-widget-box h3,
+  #auction-widget-box h4,
+  #auction-widget-box h5,
+  #auction-widget-box h6,
+  #auction-widget-box hr,
+  #auction-widget-box figure,
+  #auction-widget-box p,
+  #auction-widget-box pre {
     margin: 0;
   }
 
-  ol,
-  ul,
-  menu {
+  #auction-widget-box ol,
+  #auction-widget-box ul,
+  #auction-widget-box menu {
     list-style: none;
     margin: 0;
     padding: 0;
   }
 
   /* Reset default styling for dialogs. */
-  dialog {
+  #auction-widget-box dialog {
     padding: 0;
   }
 
@@ -568,25 +568,25 @@
     1. Reset the default placeholder opacity in Firefox. (https://github.com/tailwindlabs/tailwindcss/issues/3300)
     2. Set the default placeholder color to the user's configured gray 400 color.
   */
-  input::placeholder,
-  textarea::placeholder {
+  #auction-widget-box input::placeholder,
+  #auction-widget-box textarea::placeholder {
     opacity: 1; /* 1 */
     color: theme("colors.gray.400", #9ca3af); /* 2 */
   }
 
   /* Set the default cursor for buttons.*/
-  button,
-  [role="button"] {
+  #auction-widget-box button,
+  #auction-widget-box [role="button"] {
     cursor: pointer;
   }
 
   /* Make sure disabled buttons don't get the pointer cursor. */
-  :disabled {
+  #auction-widget-box :disabled {
     cursor: default;
   }
 
   /* Make elements with the HTML hidden attribute stay hidden by default */
-  [hidden]:where(:not([hidden="until-found"])) {
+  #auction-widget-box [hidden]:where(:not([hidden="until-found"])) {
     display: none;
   }
 }

--- a/packages/auction-widget/assets/app.css
+++ b/packages/auction-widget/assets/app.css
@@ -13,7 +13,7 @@
     --auction-widget-countdown-font: monospace;
   }
 
-  /* Base elements & reset */
+  /* Base elements */
   #auction-widget-modal-background {
     position: fixed;
     inset: 0;

--- a/packages/auction-widget/assets/app.css
+++ b/packages/auction-widget/assets/app.css
@@ -1,20 +1,5 @@
 @layer auction-widget-base, auction-widget, auction-widget-override;
 
-/* 
-  #region Auction Widget
-  Limit CSS interferences with host page with a basic reset.
-  Heritance of certain properties can be desired (e.g. font-family).
-*/
-@layer auction-widget-base {
-  #auction-widget-box svg {
-    display: inline-block;
-    height: 1.25rem;
-    width: 1.25rem;
-  }
-
-  /* TODO: add reset here */
-}
-
 /* #region Auction Widget */
 /* Style for elements and components of the Auction Widget */
 @layer auction-widget {
@@ -433,5 +418,175 @@
     #auction-widget-modal-content {
       max-width: 32rem;
     }
+  }
+}
+
+/* 
+  This layer limit CSS interferences with host page by applying a basic reset.
+  Also enforce styles consistency across browsers and devices.
+  Note: Heritance of certain properties can be desired (e.g. font-family).
+
+  This is based on Tailwind CSS « Preflight » styles -> https://tailwindcss.com/docs/preflight
+  Where I've removed some styles that are not necessary for the Auction Widget (add them if needed),
+  and added a #auction-widget-box selector to avoid conflicts with the host page.
+*/
+@layer auction-widget-base {
+  #auction-widget-box svg {
+    display: inline-block;
+    height: 1.25rem;
+    width: 1.25rem;
+  }
+
+  /*
+  1. Prevent padding and border from affecting element width. (https://github.com/mozdevs/cssremedy/issues/4)
+  2. Allow adding a border to an element by just adding a border-width. (https://github.com/tailwindcss/tailwindcss/pull/116)
+  */
+  *,
+  ::before,
+  ::after {
+    box-sizing: border-box; /* 1 */
+    border-width: 0; /* 2 */
+    border-style: solid; /* 2 */
+    border-color: theme("borderColor.DEFAULT", currentColor); /* 2 */
+  }
+
+  ::before,
+  ::after {
+    --tw-content: "";
+  }
+
+  /*
+  Remove the default font size and weight for headings.
+  */
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    font-size: inherit;
+    font-weight: inherit;
+  }
+
+  /*
+  Reset links to optimize for opt-in styling instead of opt-out.
+  */
+  a {
+    color: inherit;
+    text-decoration: inherit;
+  }
+
+  /*
+  Add the correct font weight in Edge and Safari.
+  */
+  b,
+  strong {
+    font-weight: bolder;
+  }
+
+  /*
+  1. Change the font styles in all browsers.
+  2. Remove the margin in Firefox and Safari.
+  3. Remove default padding in all browsers.
+  */
+  button,
+  input,
+  select,
+  textarea {
+    font-family: inherit; /* 1 */
+    font-feature-settings: inherit; /* 1 */
+    font-variation-settings: inherit; /* 1 */
+    font-size: 100%; /* 1 */
+    font-weight: inherit; /* 1 */
+    line-height: inherit; /* 1 */
+    letter-spacing: inherit; /* 1 */
+    color: inherit; /* 1 */
+    margin: 0; /* 2 */
+    padding: 0; /* 3 */
+  }
+
+  /* Remove the inheritance of text transform in Edge and Firefox. */
+  button,
+  select {
+    text-transform: none;
+  }
+
+  /*
+  1. Correct the inability to style clickable types in iOS and Safari.
+  2. Remove default button styles.
+  */
+  button,
+  input:where([type="button"]),
+  input:where([type="reset"]),
+  input:where([type="submit"]) {
+    -webkit-appearance: button; /* 1 */
+    background-color: transparent; /* 2 */
+    background-image: none; /* 2 */
+  }
+
+  /* Use the modern Firefox focus style for all focusable elements. */
+  :-moz-focusring {
+    outline: auto;
+  }
+
+  /* Remove the additional `:invalid` styles in Firefox. (https://github.com/mozilla/gecko-dev/blob/2f9eacd9d3d995c937b4251a5557d95d494c9be1/layout/style/res/forms.css#L728-L737) */
+  :-moz-ui-invalid {
+    box-shadow: none;
+  }
+
+  /* Removes the default spacing and border for appropriate elements. */
+  blockquote,
+  dl,
+  dd,
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6,
+  hr,
+  figure,
+  p,
+  pre {
+    margin: 0;
+  }
+
+  ol,
+  ul,
+  menu {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+  }
+
+  /* Reset default styling for dialogs. */
+  dialog {
+    padding: 0;
+  }
+
+  /*
+    1. Reset the default placeholder opacity in Firefox. (https://github.com/tailwindlabs/tailwindcss/issues/3300)
+    2. Set the default placeholder color to the user's configured gray 400 color.
+  */
+  input::placeholder,
+  textarea::placeholder {
+    opacity: 1; /* 1 */
+    color: theme("colors.gray.400", #9ca3af); /* 2 */
+  }
+
+  /* Set the default cursor for buttons.*/
+  button,
+  [role="button"] {
+    cursor: pointer;
+  }
+
+  /* Make sure disabled buttons don't get the pointer cursor. */
+  :disabled {
+    cursor: default;
+  }
+
+  /* Make elements with the HTML hidden attribute stay hidden by default */
+  [hidden]:where(:not([hidden="until-found"])) {
+    display: none;
   }
 }

--- a/packages/auction-widget/assets/app.css
+++ b/packages/auction-widget/assets/app.css
@@ -283,10 +283,11 @@
     background-color: var(--auction-widget-dark-color);
   }
 
-  #auction-widget-modal-content h3 {
+  #auction-widget-modal-title {
     font-size: 1.125rem;
     font-weight: 700;
-    line-height: 1.5rem;
+    line-height: 1.75rem;
+    margin-bottom: 1.25rem;
     text-align: center;
   }
 

--- a/packages/auction-widget/assets/app.css
+++ b/packages/auction-widget/assets/app.css
@@ -431,10 +431,14 @@
   and added a #auction-widget-box selector to avoid conflicts with the host page.
 */
 @layer auction-widget-base {
-  #auction-widget-box svg {
-    display: inline-block;
-    height: 1.25rem;
-    width: 1.25rem;
+  #auction-widget-box,
+  #auction-widget-box * {
+    /* Reset all styles to their browser defaults */
+    all: revert;
+    /* Set here the styles that we want to herit from the host page */
+    font-family: inherit;
+    color: inherit;
+    border-color: inherit;
   }
 
   /*
@@ -447,7 +451,6 @@
     box-sizing: border-box; /* 1 */
     border-width: 0; /* 2 */
     border-style: solid; /* 2 */
-    border-color: theme("borderColor.DEFAULT", currentColor); /* 2 */
   }
 
   #auction-widget-box ::before,
@@ -564,14 +567,10 @@
     padding: 0;
   }
 
-  /*
-    1. Reset the default placeholder opacity in Firefox. (https://github.com/tailwindlabs/tailwindcss/issues/3300)
-    2. Set the default placeholder color to the user's configured gray 400 color.
-  */
+  /* Reset the default placeholder opacity in Firefox. (https://github.com/tailwindlabs/tailwindcss/issues/3300)  */
   #auction-widget-box input::placeholder,
   #auction-widget-box textarea::placeholder {
-    opacity: 1; /* 1 */
-    color: theme("colors.gray.400", #9ca3af); /* 2 */
+    opacity: 1;
   }
 
   /* Set the default cursor for buttons.*/
@@ -588,5 +587,11 @@
   /* Make elements with the HTML hidden attribute stay hidden by default */
   #auction-widget-box [hidden]:where(:not([hidden="until-found"])) {
     display: none;
+  }
+
+  #auction-widget-box svg {
+    display: inline-block;
+    height: 1.25rem;
+    width: 1.25rem;
   }
 }

--- a/packages/auction-widget/src/CenteredModal.tsx
+++ b/packages/auction-widget/src/CenteredModal.tsx
@@ -17,7 +17,7 @@ const CenteredModal: Component<{
         <div id="auction-widget-modal-content">
           <Icon name={props.icon} parentClass="auction-widget-icon" />
           <div>
-            <h3>{props.title}</h3>
+            <h3 id="auction-widget-modal-title">{props.title}</h3>
             <div>{props.children}</div>
           </div>
         </div>


### PR DESCRIPTION
## What does this change?

Added CSS reset to isolate widget styles from host page and ensure consistency across browsers. This change *may cause minor visual changes* as fewer styles are inherited from the host page.

## How is it tested?

N/A.

## How is it documented?

Expected behaviour as documented.