### PR TITLE
fix(BidForm): highest bid can be null

### DIFF
--- a/.changeset/olive-parents-give.md
+++ b/.changeset/olive-parents-give.md
@@ -1,0 +1,5 @@
+---
+"@encheres-immo/widget-client": patch
+---
+
+Fixed highest bid to be null when no bid has been made yet (previously defaulted to an empty bid object).

--- a/.changeset/olive-parents-take.md
+++ b/.changeset/olive-parents-take.md
@@ -1,0 +1,5 @@
+---
+"@encheres-immo/auction-widget": patch
+---
+
+Fixes a bug where amounts were not correct upon bid confirmation.

--- a/.changeset/olive-parents-take.md
+++ b/.changeset/olive-parents-take.md
@@ -2,4 +2,4 @@
 "@encheres-immo/auction-widget": patch
 ---
 
-Fixes a bug where amounts were not correct upon bid confirmation.
+Fixed a bug where amounts were not correct upon bid confirmation.

--- a/packages/auction-widget/src/AuctionInfos.tsx
+++ b/packages/auction-widget/src/AuctionInfos.tsx
@@ -139,7 +139,7 @@ const AuctionInfos: Component<{
                 Meilleure offre
               </p>
               <p class="auction-widget-detail auction-widget-accent">
-                {props.auction.highestBid.participantId
+                {props.auction.highestBid?.participantId
                   ? displayAmountWithCurrency(
                       props.auction.highestBid.amount,
                       props.auction.currency

--- a/packages/auction-widget/src/BidForm.tsx
+++ b/packages/auction-widget/src/BidForm.tsx
@@ -173,7 +173,7 @@ const BidForm: Component<{
             <div id="auction-widget-bid-form">
               <input
                 type="number"
-                value={amount()}
+                value={defaultAmount}
                 onInput={(e) => setAmount(parseInt(e.currentTarget.value))}
                 min="0"
                 step="1"
@@ -194,13 +194,14 @@ const BidForm: Component<{
           <CenteredModal title="Vous êtes sur le point d'enchérir" icon="gavel">
             <table id="auction-widget-table">
               <tbody>
-                <Show when={props.auction.highestBid.participantId}>
+                <Show when={props.auction.highestBid?.participantId}>
                   <tr>
                     <td class="auction-widget-td">Offre précédente</td>
                     <td class="auction-widget-amount">
-                      {displayAmountWithCurrency(
-                        props.auction.highestBid.amount
-                      )}
+                      {props.auction.highestBid &&
+                        displayAmountWithCurrency(
+                          props.auction.highestBid.amount
+                        )}
                     </td>
                   </tr>
                 </Show>

--- a/packages/auction-widget/tests/BidForm.test.tsx
+++ b/packages/auction-widget/tests/BidForm.test.tsx
@@ -159,7 +159,7 @@ describe("Fast bid buttons", () => {
     ).toBeInTheDocument();
   });
 
-  test("the bid modal displays correct amounts when auction has no bids", async () => {
+  test("open the bid modal with correct amounts when auction has no bids", async () => {
     // Create an auction with no bids and no highest bid
     const auctionWithoutBids = factoryAuction({
       startingPrice: 1000,
@@ -187,7 +187,7 @@ describe("Fast bid buttons", () => {
     });
   });
 
-  test("the bid modal displays correct amounts when auction has existing bids", async () => {
+  test("open the bid modal with correct amounts when auction has existing bids", async () => {
     const highestBid: BidType = factoryBid();
 
     const auctionWithBids = factoryAuction({

--- a/packages/widget-client/src/auctions.ts
+++ b/packages/widget-client/src/auctions.ts
@@ -122,6 +122,9 @@ function formatAuction(data: any): AuctionType {
   });
 
   const highestBid = bids.reduce((acc: BidType, bid: BidType) => {
+    if (acc === null) {
+      return bid;
+    }
     return bid.amount > acc.amount ? bid : acc;
   }, null);
 

--- a/packages/widget-client/src/auctions.ts
+++ b/packages/widget-client/src/auctions.ts
@@ -121,18 +121,9 @@ function formatAuction(data: any): AuctionType {
     } as BidType;
   });
 
-  const highestBid = bids.reduce(
-    (acc: BidType, bid: BidType) => {
-      return bid.amount > acc.amount ? bid : acc;
-    },
-    {
-      id: "",
-      amount: 0,
-      createdAt: 0,
-      newEndDate: 0,
-      userAnonymousId: "",
-    } as BidType
-  );
+  const highestBid = bids.reduce((acc: BidType, bid: BidType) => {
+    return bid.amount > acc.amount ? bid : acc;
+  }, null);
 
   const registration = data.registration
     ? {

--- a/packages/widget-client/tests/auction.test.ts
+++ b/packages/widget-client/tests/auction.test.ts
@@ -1,5 +1,9 @@
 import { beforeEach, afterEach, describe, expect, it, vi, Mock } from "vitest";
-import { getNextAuctionById, subscribeToAuction, registerUserToAuction } from "../src/auctions.js";
+import {
+  getNextAuctionById,
+  subscribeToAuction,
+  registerUserToAuction,
+} from "../src/auctions.js";
 import { config } from "../index.js";
 import type { PropertyInfoType } from "../types.js";
 import { Socket } from "phoenix";
@@ -160,13 +164,7 @@ describe("getNextAuctionById", () => {
       startingPrice: 200000,
       step: 5000,
       bids: [],
-      highestBid: {
-        id: "",
-        amount: 0,
-        createdAt: 0,
-        newEndDate: 0,
-        userAnonymousId: "",
-      },
+      highestBid: null,
       agentEmail: "agent@example.com",
       agentPhone: "123456789",
       registration: null,
@@ -423,13 +421,7 @@ describe("registerUserToAuction", () => {
       startingPrice: 100000,
       step: 1000,
       bids: [],
-      highestBid: {
-        id: "",
-        amount: 0,
-        createdAt: 0,
-        newEndDate: 0,
-        userAnonymousId: "",
-      },
+      highestBid: null,
       agentEmail: "agent@example.com",
       agentPhone: "123456789",
       registration: {


### PR DESCRIPTION
## What does this change?

Fixed a bug where amounts were incorrect upon bid confirmation by allowing the highest bid to be null when no bid has been made yet (previously defaulted to an empty bid object).

## How is it tested?

Added two tests.
- Fast bids buttons open the bid modal with correct amounts when auction has no bids
- Fast bids buttons open the bid modal with correct amounts when auction has existing bids

## How is it documented?

Match expected behaviour.