### PR TITLE
fix(BidForm): no NaN value

### DIFF
--- a/.changeset/odd-impalas-heal.md
+++ b/.changeset/odd-impalas-heal.md
@@ -1,0 +1,9 @@
+---
+"@encheres-immo/auction-widget": minor
+---
+
+Fixed an error where the form would accept non-number values. Also added a new CSS variables to customize errors color.
+
+| Variable name                  | Default value |
+| ------------------------------ | ------------- |
+| `--auction-widget-error-color` | `#dc2626`     |

--- a/.changeset/odd-impalas-heal.md
+++ b/.changeset/odd-impalas-heal.md
@@ -2,7 +2,7 @@
 "@encheres-immo/auction-widget": minor
 ---
 
-Fixed an error where the form would accept non-number values. Also added a new CSS variables to customize errors color.
+Fixed an error where the form would accept non-number values. Also added a new CSS variable to customize errors color.
 
 | Variable name                  | Default value |
 | ------------------------------ | ------------- |

--- a/.github/ISSUE_TEMPLATE/01-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/01-bug-report.yml
@@ -15,7 +15,7 @@ body:
           required: false
         - label: packages/auction-widget via NPM
           required: false
-        - label: packages/auction-widget
+        - label: packages/widget-client
           required: false
         - label: Enchères Immo API
           required: false

--- a/packages/auction-widget/README.md
+++ b/packages/auction-widget/README.md
@@ -82,6 +82,7 @@ You can customize the widget by setting CSS variables in your website's styleshe
 | ---------------------------------- | ------------- |
 | `--auction-widget-highlight-color` | `#ef673d`     |
 | `--auction-widget-dark-color`      | `#002d40`     |
+| `--auction-widget-error-color`     | `#dc2626`     |
 | `--auction-widget-border-radius`   | `0.5rem`      |
 | `--auction-widget-btn-radius`      | `0.5rem`      |
 | `--auction-widget-base-font`       | `sans-serif`  |

--- a/packages/auction-widget/assets/app.css
+++ b/packages/auction-widget/assets/app.css
@@ -6,6 +6,7 @@
   :root {
     --auction-widget-highlight-color: #ef673d;
     --auction-widget-dark-color: #002d40;
+    --auction-widget-error-color: #dc2626;
     --auction-widget-border-radius: 0.5rem;
     --auction-widget-btn-radius: 0.5rem;
     --auction-widget-base-font: sans-serif;
@@ -81,10 +82,18 @@
   }
 
   .auction-widget-modal-note {
+    color: rgb(100 116 139);
     font-size: 0.875rem;
     line-height: 1.25rem;
     text-align: center;
-    color: rgb(100 116 139);
+    margin: 0;
+  }
+
+  .auction-widget-modal-warning {
+    color: var(--auction-widget-error-color);
+    font-size: 0.875rem;
+    line-height: 1.25rem;
+    text-align: center;
     margin: 0;
   }
 
@@ -369,6 +378,16 @@
     outline-offset: 1px;
     outline-color: var(--auction-widget-highlight-color);
     color: inherit;
+  }
+
+  #auction-widget-bid-form input:invalid {
+    color: var(--auction-widget-error-color);
+    outline-color: var(--auction-widget-error-color);
+  }
+
+  #auction-widget-bid-form input:valid {
+    color: inherit;
+    outline-color: var(--auction-widget-highlight-color);
   }
 
   #auction-widget-currency {

--- a/packages/auction-widget/tests/BidForm.test.tsx
+++ b/packages/auction-widget/tests/BidForm.test.tsx
@@ -260,6 +260,26 @@ describe("Modal confirm bid", () => {
     vi.restoreAllMocks();
   });
 
+  test("not displayed when the input is empty", async () => {
+    render(() => <BidForm auction={auction} isLogged={() => true} />);
+    const amountInput = screen.getByRole("spinbutton");
+    const bidButton = screen.getByText(/Enchérir/i);
+    fireEvent.input(amountInput, { target: { value: "" } });
+    fireEvent.click(bidButton);
+    // Confirm modal should not be visible
+    expect(screen.queryByText(/Vous êtes sur le point d'enchérir/i)).toBeNull();
+  });
+
+  test("not displayed when the input is invalid", async () => {
+    render(() => <BidForm auction={auction} isLogged={() => true} />);
+    const amountInput = screen.getByRole("spinbutton");
+    const bidButton = screen.getByText(/Enchérir/i);
+    fireEvent.input(amountInput, { target: { value: "NaN" } });
+    fireEvent.click(bidButton);
+    // Confirm modal should not be visible
+    expect(screen.queryByText(/Vous êtes sur le point d'enchérir/i)).toBeNull();
+  });
+
   test("places bid when confirm button is clicked", async () => {
     // Set up the mock to resolve to a bid
     (client.placeBidOnAuction as Mock).mockResolvedValue(factoryBid());


### PR DESCRIPTION
Fixes #48 

## What does this change?

Fixed an error where the form would accept non-number values. Also added a new CSS variable to customize errors color.

| Variable name                  | Default value |
| ------------------------------ | ------------- |
| `--auction-widget-error-color` | `#dc2626`     |

## How is it tested?

Two new tests:
- Modal confirm bid not displayed when the input is empty
- Modal confirm bid not displayed when the input is invalid

## How is it documented?

Updated `auction-widget`'s README with the new CSS variable.