### PR TITLE
feat(auth): reuse access token

### DIFF
--- a/.changeset/chilled-books-dont-sniff.md
+++ b/.changeset/chilled-books-dont-sniff.md
@@ -1,0 +1,5 @@
+---
+"@encheres-immo/auction-widget": minor
+---
+
+Added automatic reconnection for recently logged-in users.

--- a/.changeset/chilled-books-sniff.md
+++ b/.changeset/chilled-books-sniff.md
@@ -1,0 +1,5 @@
+---
+"@encheres-immo/widget-client": minor
+---
+
+Implemented auto-login by storing the access token in local storage and reusing it if valid in the next session.

--- a/packages/auction-widget/src/ParticipateBox.tsx
+++ b/packages/auction-widget/src/ParticipateBox.tsx
@@ -23,6 +23,12 @@ const ParticipateBox: Component<{
   allowUserRegistration: Boolean;
   tosUrl: string;
 }> = (props) => {
+  // If the presence of an access token is detected, the user was previously connected.
+  // Try to connect the user to the API with the stored access token.
+  if (localStorage.getItem("auction_widget_access_token")) {
+    tryToConnect();
+  }
+
   // If we are in the OAuth registration process, try to connect the user.
   if (props.isLogging()) {
     tryToConnect();

--- a/packages/widget-client/index.ts
+++ b/packages/widget-client/index.ts
@@ -1,6 +1,10 @@
 import { Socket } from "phoenix";
 import { authenticate, me } from "./src/auth.js";
-import { getNextAuctionById, subscribeToAuction, registerUserToAuction } from "./src/auctions.js";
+import {
+  getNextAuctionById,
+  subscribeToAuction,
+  registerUserToAuction,
+} from "./src/auctions.js";
 import { placeBidOnAuction } from "./src/bids.js";
 
 /**
@@ -48,8 +52,8 @@ export function initEIClient(
       config.WS_URL = `wss://${config.DOMAIN}/api/socket`;
       break;
     default:
-      console.log(
-        "Widget client: Unknown environment, defaulting to production."
+      console.warn(
+        "Auction Widget: Unknown environment, defaulting to production."
       );
       config.DOMAIN = "encheres-immo.com";
       config.BASE_URL = `https://${config.DOMAIN}`;

--- a/packages/widget-client/src/auctions.ts
+++ b/packages/widget-client/src/auctions.ts
@@ -19,7 +19,7 @@ export async function getNextAuctionById(
   })
     .then((response) => {
       if (response.status === 401) {
-        console.error("Unauthorized");
+        console.error("Auction Widget: Unauthorized request");
         // Throw an error or return null to stop further processing
         throw new Error("Unauthorized");
       }
@@ -27,7 +27,7 @@ export async function getNextAuctionById(
     })
     .then(formatAuction)
     .catch((err) => {
-      console.error("err", err);
+      console.error("Auction Widget: ", err);
       throw err; // Rethrow the error to be handled by the caller
     });
 }
@@ -67,7 +67,7 @@ export function subscribeToAuction(
         resolve(channel); // Resolve with the channel on successful join
       })
       .receive("error", (resp: any) => {
-        console.error("Unable to join", resp);
+        console.error("Auction Widget: Unable to join", resp);
         if (config.socket != null) {
           config.socket.disconnect();
         }
@@ -93,7 +93,7 @@ export function registerUserToAuction(auctionId: string): Promise<AuctionType> {
   })
     .then((response) => {
       if (response.status === 401) {
-        console.error("Unauthorized");
+        console.error("Auction Widget: Unauthorized request");
         // Throw an error or return null to stop further processing
         throw new Error("Unauthorized");
       }
@@ -101,7 +101,7 @@ export function registerUserToAuction(auctionId: string): Promise<AuctionType> {
     })
     .then(formatAuction)
     .catch((err) => {
-      console.error("err", err);
+      console.error("Auction Widget: ", err);
       throw err; // Rethrow the error to be handled by the caller
     });
 }

--- a/packages/widget-client/src/auth.ts
+++ b/packages/widget-client/src/auth.ts
@@ -6,6 +6,13 @@ import type { UserType } from "../types.js";
  * authorization code or redirecting the user to the authorization server to obtain it.
  */
 export async function authenticate() {
+  // Try to use the stored access token if it exists
+  const storedToken = localStorage.getItem("auction_widget_access_token");
+  if (storedToken) {
+    config.accessToken = storedToken;
+    return;
+  }
+  // Get the current URL and extract the OAuth code from the query string
   const url = window.location.href || "";
   const parsedUrl = new URL(url);
   const params = parsedUrl.searchParams;
@@ -32,8 +39,10 @@ export async function authenticate() {
         grant_type: "authorization_code",
         client_id: config.clientId,
         code: code,
-        redirect_uri: cleanRedirectUrl + "?code=" + code,
-        code_verifier: localStorage.getItem("pkce_code_verifier"),
+        redirect_uri: cleanRedirectUrl,
+        code_verifier: localStorage.getItem(
+          "auction_widget_pkce_code_verifier"
+        ),
       }),
     })
       .then((response) => {
@@ -41,19 +50,22 @@ export async function authenticate() {
       })
       .then((data) => {
         // With the access token, we can now access the protected resource
-        localStorage.removeItem("pkce_code_verifier");
+        localStorage.removeItem("auction_widget_pkce_code_verifier");
         config.accessToken = data.access_token;
+        // Store the token so User can be authenticated on future visits
+        localStorage.setItem("auction_widget_access_token", data.access_token);
         return null;
       })
       .catch((err) => {
-        console.error(err);
+        console.error("Auction Widget: ", err);
+        console.error("Auction Widget: ", err);
       });
   } else {
     // If there is no code in the query, then redirect to the authorization server
     let state = generateRandomString();
     let codeChallengeMethod = "S256";
     let CODE_VERIFIER = generateRandomString();
-    localStorage.setItem("pkce_code_verifier", CODE_VERIFIER);
+    localStorage.setItem("auction_widget_pkce_code_verifier", CODE_VERIFIER);
     let codeChallenge = await pkceChallengeFromVerifier(CODE_VERIFIER);
     let redirect_oauth_url = `${config.BASE_URL}/oauth/authorize?response_type=code&client_id=${config.clientId}&redirect_uri=${cleanRedirectUrl}&state=${encodeURIComponent(state)}&code_challenge=${encodeURIComponent(codeChallenge)}&code_challenge_method=${codeChallengeMethod}`;
     window.location.assign(redirect_oauth_url);
@@ -71,15 +83,25 @@ export async function me(): Promise<UserType | undefined> {
       },
     });
 
+    if (response.status === 401) {
+      console.error("Auction Widget: Unauthorized request");
+      // Clear the stored access token since it's invalid
+      localStorage.removeItem("auction_widget_access_token");
+      return undefined;
+    }
+
     if (!response.ok) {
       const errorData = await response.json();
-      console.error(errorData.error || "Error fetching user details");
+      console.error(
+        "Auction Widget: ",
+        errorData.error || "Error fetching user details"
+      );
       return undefined;
     }
 
     const data = await response.json();
     if (!data || !data.id) {
-      console.error("Invalid user data");
+      console.error("Auction Widget: Invalid user data");
       return undefined;
     }
 
@@ -88,7 +110,7 @@ export async function me(): Promise<UserType | undefined> {
       email: data.email,
     };
   } catch (error) {
-    console.error("Error fetching user details:", error);
+    console.error("Auction Widget: Error fetching user details. ", error);
     return undefined;
   }
 }

--- a/packages/widget-client/src/bids.ts
+++ b/packages/widget-client/src/bids.ts
@@ -21,7 +21,7 @@ export async function placeBidOnAuction(
   })
     .then((response) => {
       if (response.status === 401) {
-        console.error("Unauthorized");
+        console.error("Auction Widget: Unauthorized request");
         throw new Error("Unauthorized");
       }
       if (response.status === 422) {
@@ -42,7 +42,7 @@ export async function placeBidOnAuction(
       } as BidType;
     })
     .catch((err) => {
-      console.error("err", err);
+      console.error("Auction Widget: ", err);
       throw err;
     });
 }

--- a/packages/widget-client/tests/auction.test.ts
+++ b/packages/widget-client/tests/auction.test.ts
@@ -196,7 +196,9 @@ describe("getNextAuctionById", () => {
     );
 
     // Verify 'Unauthorized' is logged
-    expect(consoleLogSpy).toHaveBeenCalledWith("Unauthorized");
+    expect(consoleLogSpy).toHaveBeenCalledWith(
+      "Auction Widget: Unauthorized request"
+    );
   });
 
   it("should throw an error when fetch fails", async () => {
@@ -213,7 +215,7 @@ describe("getNextAuctionById", () => {
     );
 
     // Verify error is logged
-    expect(console.error).toHaveBeenCalledWith("err", mockError);
+    expect(console.error).toHaveBeenCalledWith("Auction Widget: ", mockError);
   });
 });
 
@@ -455,7 +457,9 @@ describe("registerUserToAuction", () => {
     );
 
     // Verify 'Unauthorized' is logged
-    expect(consoleLogSpy).toHaveBeenCalledWith("Unauthorized");
+    expect(consoleLogSpy).toHaveBeenCalledWith(
+      "Auction Widget: Unauthorized request"
+    );
   });
 
   it("should throw an error when fetch fails", async () => {
@@ -470,6 +474,6 @@ describe("registerUserToAuction", () => {
     );
 
     // Verify error is logged
-    expect(console.error).toHaveBeenCalledWith("err", mockError);
+    expect(console.error).toHaveBeenCalledWith("Auction Widget: ", mockError);
   });
 });

--- a/packages/widget-client/tests/auth.test.ts
+++ b/packages/widget-client/tests/auth.test.ts
@@ -42,7 +42,10 @@ describe("Authentication", () => {
     window.location.href = "https://example.com/?code=test-code";
 
     // Set code_verifier in localStorage
-    localStorage.setItem("pkce_code_verifier", "test-code-verifier");
+    localStorage.setItem(
+      "auction_widget_pkce_code_verifier",
+      "test-code-verifier"
+    );
 
     // Mock fetch to return access token
     (fetch as Mock).mockResolvedValue({
@@ -62,7 +65,7 @@ describe("Authentication", () => {
           grant_type: "authorization_code",
           client_id: "test-client-id",
           code: "test-code",
-          redirect_uri: "https://example.com/?code=test-code",
+          redirect_uri: "https://example.com/",
           code_verifier: "test-code-verifier",
         }),
       })
@@ -71,8 +74,10 @@ describe("Authentication", () => {
     // Check that accessToken is set
     expect(config.accessToken).toBe("test-access-token");
 
-    // Check that pkce_code_verifier is removed from localStorage
-    expect(localStorage.getItem("pkce_code_verifier")).toBeNull();
+    // Check that auction_widget_pkce_code_verifier is removed from localStorage
+    expect(
+      localStorage.getItem("auction_widget_pkce_code_verifier")
+    ).toBeNull();
 
     // Check that window.history.replaceState was called to remove code from URL
     expect(window.history.replaceState).toHaveBeenCalled();
@@ -99,10 +104,11 @@ describe("Authentication", () => {
     window.location.href =
       "https://example.com/?code=test-code&state=test-state#anchor";
 
-    console.log("Test: ", window.location.origin + window.location.pathname);
-
     // Set code_verifier in localStorage
-    localStorage.setItem("pkce_code_verifier", "test-code-verifier");
+    localStorage.setItem(
+      "auction_widget_pkce_code_verifier",
+      "test-code-verifier"
+    );
 
     // Mock fetch to return access token
     (fetch as Mock).mockResolvedValue({
@@ -122,7 +128,7 @@ describe("Authentication", () => {
           grant_type: "authorization_code",
           client_id: "test-client-id",
           code: "test-code",
-          redirect_uri: "https://example.com/?code=test-code",
+          redirect_uri: "https://example.com/",
           code_verifier: "test-code-verifier",
         }),
       })
@@ -177,7 +183,9 @@ describe("User Information", () => {
     const user = await me();
 
     // Check that 'Unauthorized' is logged
-    expect(consoleLogSpy).toHaveBeenCalledWith("Unauthorized");
+    expect(consoleLogSpy).toHaveBeenCalledWith(
+      "Auction Widget: Unauthorized request"
+    );
 
     // Check that user is undefined
     expect(user).toBeUndefined();

--- a/packages/widget-client/tests/bids.test.ts
+++ b/packages/widget-client/tests/bids.test.ts
@@ -123,7 +123,9 @@ describe("placeBidOnAuction", () => {
     );
 
     // Verify 'Unauthorized' is logged
-    expect(consoleLogSpy).toHaveBeenCalledWith("Unauthorized");
+    expect(consoleLogSpy).toHaveBeenCalledWith(
+      "Auction Widget: Unauthorized request"
+    );
   });
 
   it("should handle validation errors with status 422", async () => {
@@ -199,6 +201,6 @@ describe("placeBidOnAuction", () => {
     );
 
     // Verify error is logged
-    expect(console.error).toHaveBeenCalledWith("err", mockError);
+    expect(console.error).toHaveBeenCalledWith("Auction Widget: ", mockError);
   });
 });


### PR DESCRIPTION
Fixes #47 , but opens #55

## What does this change?

Implemented auto-login by storing the access token in local storage and reusing it if valid in the next session. 

On the side, I added a prefix on console logs and local storage items.

## How is it tested?

:(

## How is it documented?

:(