### PR TITLE
feat: allow-user-registration allows to create an account

### DIFF
--- a/.changeset/mean-planets-filter.md
+++ b/.changeset/mean-planets-filter.md
@@ -1,0 +1,5 @@
+---
+"@encheres-immo/auction-widget": minor
+---
+
+Added a link to create an account when `allow-user-registration` is set to `true`. If false, the agent's contact information will be displayed instead.

--- a/.changeset/mean-planets-sort.md
+++ b/.changeset/mean-planets-sort.md
@@ -1,0 +1,5 @@
+---
+"@encheres-immo/widget-client": minor
+---
+
+Added a function to get the registration link, allowing users to create an account on the platform before getting redirected to the auction page.

--- a/packages/auction-widget/README.md
+++ b/packages/auction-widget/README.md
@@ -69,10 +69,10 @@ Alternatively, you can retrieve your property from a CRM by replacing `property-
 
 You can enable or disable features of the widget by setting the corresponding attributes on the HTML tag. Here are the available features:
 
-| Attribute                 | Default                         | Description                                                                                                                                                                                                                              |
-| ------------------------- | ------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `allow-user-registration` | `true`                          | Display a button to allow users to register for the auction—This registration must be accepted by the agent later, or the user will not be able to place bids. If set to `false`, agent's contact information will be displayed instead. |
-| `tos-url`                 | `https://encheres-immo.com/cgu` | URL to your custom terms of service page for auctions, must be a valid URL and confirmed by Enchères Immo.                                                                                                                               |
+| Attribute                 | Default                         | Description                                                                                                                                                                                                                                                    |
+| ------------------------- | ------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `allow-user-registration` | `true`                          | Display a button to allow users to create an account and register for the auction—This registration must be accepted by the agent later, or the user will not be able to place bids. If set to `false`, agent's contact information will be displayed instead. |
+| `tos-url`                 | `https://encheres-immo.com/cgu` | URL to your custom terms of service page for auctions, must be a valid URL and confirmed by Enchères Immo.                                                                                                                                                     |
 
 ### Styling
 

--- a/packages/auction-widget/src/ParticipateBox.tsx
+++ b/packages/auction-widget/src/ParticipateBox.tsx
@@ -102,15 +102,24 @@ const ParticipateBox: Component<{
           </div>
           <div id="auction-widget-agent-link">
             <p class="auction-widget-modal-note">Pas encore de compte ?</p>
-            <button
-              id="auction-widget-link"
-              onClick={() => {
-                setIsContactModalOpen(true);
-                setOpenModal(false);
-              }}
+            <Show
+              when={props.allowUserRegistration}
+              fallback={
+                <button
+                  id="auction-widget-link"
+                  onClick={() => {
+                    setIsContactModalOpen(true);
+                    setOpenModal(false);
+                  }}
+                >
+                  Contacter l'agent
+                </button>
+              }
             >
-              Contacter l'agent
-            </button>
+              <a id="auction-widget-link" href={client.registration()}>
+                Inscrivez-vous
+              </a>
+            </Show>
           </div>
         </CenteredModal>
       </Show>

--- a/packages/auction-widget/tests/ParticipateBox.test.tsx
+++ b/packages/auction-widget/tests/ParticipateBox.test.tsx
@@ -26,6 +26,7 @@ vi.mock("@encheres-immo/widget-client", () => {
   return {
     default: {
       authenticate: vi.fn(),
+      registration: vi.fn(),
       me: vi.fn(),
       registerUserToAuction: vi.fn(),
     },
@@ -46,6 +47,7 @@ describe("Participate Button", () => {
     updateUser = vi.fn();
     setAuction = vi.fn();
     (client.authenticate as Mock).mockReset();
+    (client.registration as Mock).mockReset();
     (client.me as Mock).mockReset();
     (client.registerUserToAuction as Mock).mockReset();
   });
@@ -136,6 +138,7 @@ describe("Login Modal", () => {
     updateUser = vi.fn();
     setAuction = vi.fn();
     (client.authenticate as Mock).mockReset();
+    (client.registration as Mock).mockReset();
     (client.me as Mock).mockReset();
     (client.registerUserToAuction as Mock).mockReset();
   });
@@ -207,6 +210,7 @@ describe("Registration Modal", () => {
     updateUser = vi.fn();
     setAuction = vi.fn();
     (client.authenticate as Mock).mockReset();
+    (client.registration as Mock).mockReset();
     (client.me as Mock).mockReset();
     (client.registerUserToAuction as Mock).mockReset();
   });
@@ -342,6 +346,7 @@ describe("Contact Modal", () => {
     updateUser = vi.fn();
     setAuction = vi.fn();
     (client.authenticate as Mock).mockReset();
+    (client.registration as Mock).mockReset();
     (client.me as Mock).mockReset();
     (client.registerUserToAuction as Mock).mockReset();
   });
@@ -351,7 +356,7 @@ describe("Contact Modal", () => {
     vi.restoreAllMocks();
   });
 
-  test("can be opened from login modal", () => {
+  test("can be opened from login modal when allowUserRegistration is false", () => {
     render(() => (
       <ParticipateBox
         propertyInfo={factoryPropertyInfo()}
@@ -360,7 +365,7 @@ describe("Contact Modal", () => {
         isLogged={() => false}
         isLogging={() => false}
         auction={auction}
-        allowUserRegistration={true}
+        allowUserRegistration={false}
         tosUrl=""
       />
     ));
@@ -372,6 +377,25 @@ describe("Contact Modal", () => {
     expect(
       screen.queryByText("Vous devez être connecté")
     ).not.toBeInTheDocument();
+  });
+
+  test("can't be opened from registration modal when allowUserRegistration is false", () => {
+    render(() => (
+      <ParticipateBox
+        propertyInfo={factoryPropertyInfo()}
+        updateUser={updateUser}
+        setAuction={setAuction}
+        isLogged={() => true}
+        isLogging={() => false}
+        auction={auction}
+        allowUserRegistration={false}
+        tosUrl=""
+      />
+    ));
+
+    fireEvent.click(screen.getByText("Je veux participer"));
+
+    expect(screen.queryByText("Contacter l'agent")).not.toBeInTheDocument();
   });
 
   test("displays agent contact information", () => {

--- a/packages/widget-client/index.ts
+++ b/packages/widget-client/index.ts
@@ -1,5 +1,5 @@
 import { Socket } from "phoenix";
-import { authenticate, me } from "./src/auth.js";
+import { authenticate, me, registration } from "./src/auth.js";
 import {
   getNextAuctionById,
   subscribeToAuction,
@@ -66,6 +66,7 @@ export default {
   initEIClient,
   getNextAuctionById,
   authenticate,
+  registration,
   subscribeToAuction,
   registerUserToAuction,
   me,

--- a/packages/widget-client/src/auth.ts
+++ b/packages/widget-client/src/auth.ts
@@ -2,6 +2,14 @@ import { config } from "../index.js";
 import type { UserType } from "../types.js";
 
 /**
+ * Returns the new registration URL.
+ */
+export function registration(): string {
+  const cleanRedirectUrl = window.location.origin + window.location.pathname;
+  return `${config.BASE_URL}/register?org_id=${config.clientId}&user_return_to=${cleanRedirectUrl}`;
+}
+
+/**
  * Handles the OAuth2 authentication process by either fetching an access token using an
  * authorization code or redirecting the user to the authorization server to obtain it.
  */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -97,8 +97,8 @@ importers:
         specifier: ^6.0.11
         version: 6.0.11(terser@5.31.0)(yaml@2.7.0)
       vitest:
-        specifier: ^3.0.4
-        version: 3.0.4(@types/debug@4.1.12)(jsdom@26.0.0)(terser@5.31.0)(yaml@2.7.0)
+        specifier: ^2.1.8
+        version: 2.1.8(jsdom@26.0.0)(terser@5.31.0)
 
 packages:
 
@@ -1216,9 +1216,6 @@ packages:
   '@vitest/expect@2.1.8':
     resolution: {integrity: sha512-8ytZ/fFHq2g4PJVAtDX57mayemKgDR6X3Oa2Foro+EygiOJHUXhCqBAAKQYYajZpFoIfvBCF1j6R6IYRSIUFuw==}
 
-  '@vitest/expect@3.0.4':
-    resolution: {integrity: sha512-Nm5kJmYw6P2BxhJPkO3eKKhGYKRsnqJqf+r0yOGRKpEP+bSCBDsjXgiu1/5QFrnPMEgzfC38ZEjvCFgaNBC0Eg==}
-
   '@vitest/mocker@2.1.8':
     resolution: {integrity: sha512-7guJ/47I6uqfttp33mgo6ga5Gr1VnL58rcqYKyShoRK9ebu8T5Rs6HN3s1NABiBeVTdWNrwUMcHH54uXZBN4zA==}
     peerDependencies:
@@ -1230,46 +1227,20 @@ packages:
       vite:
         optional: true
 
-  '@vitest/mocker@3.0.4':
-    resolution: {integrity: sha512-gEef35vKafJlfQbnyOXZ0Gcr9IBUsMTyTLXsEQwuyYAerpHqvXhzdBnDFuHLpFqth3F7b6BaFr4qV/Cs1ULx5A==}
-    peerDependencies:
-      msw: ^2.4.9
-      vite: ^5.0.0 || ^6.0.0
-    peerDependenciesMeta:
-      msw:
-        optional: true
-      vite:
-        optional: true
-
   '@vitest/pretty-format@2.1.8':
     resolution: {integrity: sha512-9HiSZ9zpqNLKlbIDRWOnAWqgcA7xu+8YxXSekhr0Ykab7PAYFkhkwoqVArPOtJhPmYeE2YHgKZlj3CP36z2AJQ==}
-
-  '@vitest/pretty-format@3.0.4':
-    resolution: {integrity: sha512-ts0fba+dEhK2aC9PFuZ9LTpULHpY/nd6jhAQ5IMU7Gaj7crPCTdCFfgvXxruRBLFS+MLraicCuFXxISEq8C93g==}
 
   '@vitest/runner@2.1.8':
     resolution: {integrity: sha512-17ub8vQstRnRlIU5k50bG+QOMLHRhYPAna5tw8tYbj+jzjcspnwnwtPtiOlkuKC4+ixDPTuLZiqiWWQ2PSXHVg==}
 
-  '@vitest/runner@3.0.4':
-    resolution: {integrity: sha512-dKHzTQ7n9sExAcWH/0sh1elVgwc7OJ2lMOBrAm73J7AH6Pf9T12Zh3lNE1TETZaqrWFXtLlx3NVrLRb5hCK+iw==}
-
   '@vitest/snapshot@2.1.8':
     resolution: {integrity: sha512-20T7xRFbmnkfcmgVEz+z3AU/3b0cEzZOt/zmnvZEctg64/QZbSDJEVm9fLnnlSi74KibmRsO9/Qabi+t0vCRPg==}
-
-  '@vitest/snapshot@3.0.4':
-    resolution: {integrity: sha512-+p5knMLwIk7lTQkM3NonZ9zBewzVp9EVkVpvNta0/PlFWpiqLaRcF4+33L1it3uRUCh0BGLOaXPPGEjNKfWb4w==}
 
   '@vitest/spy@2.1.8':
     resolution: {integrity: sha512-5swjf2q95gXeYPevtW0BLk6H8+bPlMb4Vw/9Em4hFxDcaOxS+e0LOX4yqNxoHzMR2akEB2xfpnWUzkZokmgWDg==}
 
-  '@vitest/spy@3.0.4':
-    resolution: {integrity: sha512-sXIMF0oauYyUy2hN49VFTYodzEAu744MmGcPR3ZBsPM20G+1/cSW/n1U+3Yu/zHxX2bIDe1oJASOkml+osTU6Q==}
-
   '@vitest/utils@2.1.8':
     resolution: {integrity: sha512-dwSoui6djdwbfFmIgbIjX2ZhIoG7Ex/+xpxyiEgIGzjliY8xGkcpITKTlp6B4MgtGkF2ilvm97cPM96XZaAgcA==}
-
-  '@vitest/utils@3.0.4':
-    resolution: {integrity: sha512-8BqC1ksYsHtbWH+DfpOAKrFw3jl3Uf9J7yeFh85Pz52IWuh1hBBtyfEbRNNZNjl8H8A5yMLH9/t+k7HIKzQcZQ==}
 
   '@volar/kit@2.4.11':
     resolution: {integrity: sha512-ups5RKbMzMCr6RKafcCqDRnJhJDNWqo2vfekwOAj6psZ15v5TlcQFQAyokQJ3wZxVkzxrQM+TqTRDENfQEXpmA==}
@@ -2290,9 +2261,6 @@ packages:
   pathe@1.1.2:
     resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
 
-  pathe@2.0.2:
-    resolution: {integrity: sha512-15Ztpk+nov8DR524R4BF7uEuzESgzUEAV4Ah7CUMNGXdE5ELuvxElxGXndBl32vMSsWa1jpNf22Z+Er3sKwq+w==}
-
   pathval@2.0.0:
     resolution: {integrity: sha512-vE7JKRyES09KiunauX7nd2Q9/L7lhok4smP9RZTDeD4MVs72Dp2qNFVz39Nz5a0FVEW0BJR6C0DYrq6unoziZA==}
     engines: {node: '>= 14.16'}
@@ -2689,10 +2657,6 @@ packages:
     resolution: {integrity: sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==}
     engines: {node: '>=14.0.0'}
 
-  tinyrainbow@2.0.0:
-    resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
-    engines: {node: '>=14.0.0'}
-
   tinyspy@3.0.2:
     resolution: {integrity: sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==}
     engines: {node: '>=14.0.0'}
@@ -2882,11 +2846,6 @@ packages:
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
 
-  vite-node@3.0.4:
-    resolution: {integrity: sha512-7JZKEzcYV2Nx3u6rlvN8qdo3QV7Fxyt6hx+CCKz9fbWxdX5IvUOmTWEAxMrWxaiSf7CKGLJQ5rFu8prb/jBjOA==}
-    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
-    hasBin: true
-
   vite-plugin-solid@2.11.0:
     resolution: {integrity: sha512-G+NiwDj4EAeUE0wt3Ur9f+Lt9oMUuLd0FIxYuqwJSqRacKQRteCwUFzNy8zMEt88xWokngQhiFjfJMhjc1fDXw==}
     peerDependencies:
@@ -2989,34 +2948,6 @@ packages:
       jsdom: '*'
     peerDependenciesMeta:
       '@edge-runtime/vm':
-        optional: true
-      '@types/node':
-        optional: true
-      '@vitest/browser':
-        optional: true
-      '@vitest/ui':
-        optional: true
-      happy-dom:
-        optional: true
-      jsdom:
-        optional: true
-
-  vitest@3.0.4:
-    resolution: {integrity: sha512-6XG8oTKy2gnJIFTHP6LD7ExFeNLxiTkK3CfMvT7IfR8IN+BYICCf0lXUQmX7i7JoxUP8QmeP4mTnWXgflu4yjw==}
-    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
-    hasBin: true
-    peerDependencies:
-      '@edge-runtime/vm': '*'
-      '@types/debug': ^4.1.12
-      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
-      '@vitest/browser': 3.0.4
-      '@vitest/ui': 3.0.4
-      happy-dom: '*'
-      jsdom: '*'
-    peerDependenciesMeta:
-      '@edge-runtime/vm':
-        optional: true
-      '@types/debug':
         optional: true
       '@types/node':
         optional: true
@@ -4391,13 +4322,6 @@ snapshots:
       chai: 5.1.2
       tinyrainbow: 1.2.0
 
-  '@vitest/expect@3.0.4':
-    dependencies:
-      '@vitest/spy': 3.0.4
-      '@vitest/utils': 3.0.4
-      chai: 5.1.2
-      tinyrainbow: 2.0.0
-
   '@vitest/mocker@2.1.8(vite@5.4.14(terser@5.31.0))':
     dependencies:
       '@vitest/spy': 2.1.8
@@ -4406,31 +4330,14 @@ snapshots:
     optionalDependencies:
       vite: 5.4.14(terser@5.31.0)
 
-  '@vitest/mocker@3.0.4(vite@6.0.11(terser@5.31.0)(yaml@2.7.0))':
-    dependencies:
-      '@vitest/spy': 3.0.4
-      estree-walker: 3.0.3
-      magic-string: 0.30.17
-    optionalDependencies:
-      vite: 6.0.11(terser@5.31.0)(yaml@2.7.0)
-
   '@vitest/pretty-format@2.1.8':
     dependencies:
       tinyrainbow: 1.2.0
-
-  '@vitest/pretty-format@3.0.4':
-    dependencies:
-      tinyrainbow: 2.0.0
 
   '@vitest/runner@2.1.8':
     dependencies:
       '@vitest/utils': 2.1.8
       pathe: 1.1.2
-
-  '@vitest/runner@3.0.4':
-    dependencies:
-      '@vitest/utils': 3.0.4
-      pathe: 2.0.2
 
   '@vitest/snapshot@2.1.8':
     dependencies:
@@ -4438,17 +4345,7 @@ snapshots:
       magic-string: 0.30.17
       pathe: 1.1.2
 
-  '@vitest/snapshot@3.0.4':
-    dependencies:
-      '@vitest/pretty-format': 3.0.4
-      magic-string: 0.30.17
-      pathe: 2.0.2
-
   '@vitest/spy@2.1.8':
-    dependencies:
-      tinyspy: 3.0.2
-
-  '@vitest/spy@3.0.4':
     dependencies:
       tinyspy: 3.0.2
 
@@ -4457,12 +4354,6 @@ snapshots:
       '@vitest/pretty-format': 2.1.8
       loupe: 3.1.2
       tinyrainbow: 1.2.0
-
-  '@vitest/utils@3.0.4':
-    dependencies:
-      '@vitest/pretty-format': 3.0.4
-      loupe: 3.1.2
-      tinyrainbow: 2.0.0
 
   '@volar/kit@2.4.11(typescript@5.7.3)':
     dependencies:
@@ -5806,8 +5697,6 @@ snapshots:
 
   pathe@1.1.2: {}
 
-  pathe@2.0.2: {}
-
   pathval@2.0.0: {}
 
   phoenix@1.7.18: {}
@@ -6240,8 +6129,6 @@ snapshots:
 
   tinyrainbow@1.2.0: {}
 
-  tinyrainbow@2.0.0: {}
-
   tinyspy@3.0.2: {}
 
   tldts-core@6.1.75: {}
@@ -6406,27 +6293,6 @@ snapshots:
       - supports-color
       - terser
 
-  vite-node@3.0.4(terser@5.31.0)(yaml@2.7.0):
-    dependencies:
-      cac: 6.7.14
-      debug: 4.4.0
-      es-module-lexer: 1.6.0
-      pathe: 2.0.2
-      vite: 6.0.11(terser@5.31.0)(yaml@2.7.0)
-    transitivePeerDependencies:
-      - '@types/node'
-      - jiti
-      - less
-      - lightningcss
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - yaml
-
   vite-plugin-solid@2.11.0(@testing-library/jest-dom@6.6.3)(solid-js@1.9.4)(vite@6.0.11(terser@5.31.0)(yaml@2.7.0)):
     dependencies:
       '@babel/core': 7.26.7
@@ -6499,45 +6365,6 @@ snapshots:
       - sugarss
       - supports-color
       - terser
-
-  vitest@3.0.4(@types/debug@4.1.12)(jsdom@26.0.0)(terser@5.31.0)(yaml@2.7.0):
-    dependencies:
-      '@vitest/expect': 3.0.4
-      '@vitest/mocker': 3.0.4(vite@6.0.11(terser@5.31.0)(yaml@2.7.0))
-      '@vitest/pretty-format': 3.0.4
-      '@vitest/runner': 3.0.4
-      '@vitest/snapshot': 3.0.4
-      '@vitest/spy': 3.0.4
-      '@vitest/utils': 3.0.4
-      chai: 5.1.2
-      debug: 4.4.0
-      expect-type: 1.1.0
-      magic-string: 0.30.17
-      pathe: 2.0.2
-      std-env: 3.8.0
-      tinybench: 2.9.0
-      tinyexec: 0.3.2
-      tinypool: 1.0.2
-      tinyrainbow: 2.0.0
-      vite: 6.0.11(terser@5.31.0)(yaml@2.7.0)
-      vite-node: 3.0.4(terser@5.31.0)(yaml@2.7.0)
-      why-is-node-running: 2.3.0
-    optionalDependencies:
-      '@types/debug': 4.1.12
-      jsdom: 26.0.0
-    transitivePeerDependencies:
-      - jiti
-      - less
-      - lightningcss
-      - msw
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - yaml
 
   volar-service-css@0.0.62(@volar/language-service@2.4.11):
     dependencies:


### PR DESCRIPTION
## What does this change?

Fixes #51 . Added a link to create an account when `allow-user-registration` is set to `true`. If false, the agent's contact information will be displayed instead.

## How is it tested?

Updated `packages/auction-widget/tests/ParticipateBox.test.tsx`.

## How is it documented?

Updated `packages/auction-widget/README.md`.