### PR TITLE
fix(BidForm): bid input default value update

### DIFF
--- a/.changeset/twenty-hounds-yell.md
+++ b/.changeset/twenty-hounds-yell.md
@@ -1,0 +1,5 @@
+---
+"@encheres-immo/auction-widget": patch
+---
+
+Fixed a bug where the bid input's default value was not updated correctly when new bids were placed.

--- a/packages/auction-widget/src/BidForm.tsx
+++ b/packages/auction-widget/src/BidForm.tsx
@@ -17,10 +17,10 @@ const BidForm: Component<{
   auction: AuctionType;
   clock?: () => number;
 }> = (props) => {
-  const defaultAmount = getBaseAmount(props.auction);
+  // Initialize amount using current auction data.
+  const [amount, setAmount] = createSignal(getBaseAmount(props.auction));
   const [isAuctionInProgressSignal, setIsAuctionInProgressSignal] =
     createSignal(isAuctionInProgress(props.auction));
-  let [amount, setAmount] = createSignal(defaultAmount);
   const [isConfirmBidOpen, setIsConfirmBidOpen] = createSignal(false);
   const [isShowMinMessage, setIsShowMinMessage] = createSignal(false);
   const [isAmountTooHigh, setIsAmountTooHigh] = createSignal(false);
@@ -40,6 +40,11 @@ const BidForm: Component<{
       ? auction.highestBid.amount + auction.step
       : auction.startingPrice;
   }
+
+  // Update the default bid amount whenever the auction prop changes (e.g. a new highest bid)
+  createEffect(() => {
+    setAmount(getBaseAmount(props.auction));
+  });
 
   /**
    * We display a warning message if the bid amount is too high.
@@ -211,9 +216,10 @@ const BidForm: Component<{
               Votre montant
             </p>
             <form id="auction-widget-bid-form" onSubmit={openConfirmBid()}>
+              {/* Bind the input's value to the reactive signal "amount" */}
               <input
                 type="number"
-                value={defaultAmount}
+                value={amount()}
                 onInput={(e) =>
                   setAmount(Number.parseInt(e.currentTarget.value))
                 }


### PR DESCRIPTION
## What does this change?

Fixed a bug where the bid input's default value was not updated correctly when new bids were placed.

## How is it tested?

Add a test in `packages/auction-widget/tests/BidForm.test.tsx`.

## How is it documented?

Expected behaviour.