### PR TITLE
feat(auction-widget): update using auction status 

### DIFF
--- a/.changeset/old-seahorses-run.md
+++ b/.changeset/old-seahorses-run.md
@@ -1,0 +1,5 @@
+---
+"@encheres-immo/widget-client": minor
+---
+
+Added `status` property to the `Auction` type.

--- a/.changeset/young-seahorses-run.md
+++ b/.changeset/young-seahorses-run.md
@@ -1,0 +1,5 @@
+---
+"@encheres-immo/auction-widget": patch
+---
+
+Fixed a bug where auction informations were not always updated dynamically. Also, performance improvements.

--- a/packages/auction-widget/src/App.tsx
+++ b/packages/auction-widget/src/App.tsx
@@ -24,6 +24,7 @@ const [user, setUser] = createSignal<UserType | undefined>(undefined);
 const [bids, setBids] = createStore<BidType[]>([]);
 const [auction, setAuction] = createStore<AuctionType>({
   id: "",
+  status: "draft",
   startDate: 0,
   endDate: 0,
   startingPrice: 0,
@@ -86,7 +87,7 @@ function refreshAuction(propertyInfo: PropertyInfoType) {
             },
           });
           document.getElementById("auction-widget")?.dispatchEvent(event);
-          // replace highest bid in auction
+          // replace highest bid in auction and update end date if needed
           const newEndDate = bid.newEndDate || auction.endDate;
           setAuction({
             ...auction,
@@ -159,9 +160,9 @@ const App: Component<{
           allowUserRegistration={allowUserRegistration}
           tosUrl={tosUrl}
         />
-        <RegistrationStatus isLogged={isLogged} auction={auction} />
-        <BidForm auction={auction} isLogged={isLogged} clock={clock} />
-        <BidHistory bids={bids} auction={auction} user={user()} clock={clock} />
+        <RegistrationStatus auction={auction} isLogged={isLogged} />
+        <BidForm auction={auction} isLogged={isLogged} />
+        <BidHistory auction={auction} bids={bids} user={user()} clock={clock} />
       </Show>
       <Spritesheet />
     </div>

--- a/packages/auction-widget/src/App.tsx
+++ b/packages/auction-widget/src/App.tsx
@@ -52,17 +52,6 @@ const [auction, setAuction] = createStore<AuctionType>({
     isBefore: false,
   },
 });
-const [clock, setClock] = createSignal(Date.now());
-
-/**
- * Used to update our widget every second.
- */
-onMount(() => {
-  const interval = setInterval(() => {
-    setClock(Date.now());
-  }, 1000);
-  return () => clearInterval(interval);
-});
 
 /**
  * Refresh auction data and subscribe to auction events (new bid, end of auction)
@@ -149,7 +138,7 @@ const App: Component<{
   return (
     <div id="auction-widget-box">
       <Show when={auction.id != ""}>
-        <AuctionInfos auction={auction} user={user()} clock={clock} />
+        <AuctionInfos auction={auction} user={user()} />
         <ParticipateBox
           auction={auction}
           propertyInfo={propertyInfo}
@@ -162,7 +151,7 @@ const App: Component<{
         />
         <RegistrationStatus auction={auction} isLogged={isLogged} />
         <BidForm auction={auction} isLogged={isLogged} />
-        <BidHistory auction={auction} bids={bids} user={user()} clock={clock} />
+        <BidHistory auction={auction} bids={bids} user={user()} />
       </Show>
       <Spritesheet />
     </div>

--- a/packages/auction-widget/src/BidForm.tsx
+++ b/packages/auction-widget/src/BidForm.tsx
@@ -15,7 +15,6 @@ import CenteredModal from "./CenteredModal.jsx";
 const BidForm: Component<{
   isLogged: () => boolean;
   auction: AuctionType;
-  clock?: () => number;
 }> = (props) => {
   // Initialize amount using current auction data.
   const [amount, setAmount] = createSignal(getBaseAmount(props.auction));
@@ -164,9 +163,9 @@ const BidForm: Component<{
     document.getElementById("auction-widget")?.dispatchEvent(event);
   }
 
-  // Use a reactive effect to update the auction state based on the global clock.
+  // Update auction progress state when relevant auction properties change
   createEffect(() => {
-    props.clock && props.clock(); // Reacts to changes in the global clock
+    const { status, startDate, endDate } = props.auction;
     setIsAuctionInProgressSignal(isAuctionInProgress(props.auction));
   });
 

--- a/packages/auction-widget/src/BidForm.tsx
+++ b/packages/auction-widget/src/BidForm.tsx
@@ -165,7 +165,6 @@ const BidForm: Component<{
 
   // Update auction progress state when relevant auction properties change
   createEffect(() => {
-    const { status, startDate, endDate } = props.auction;
     setIsAuctionInProgressSignal(isAuctionInProgress(props.auction));
   });
 

--- a/packages/auction-widget/src/BidHistory.tsx
+++ b/packages/auction-widget/src/BidHistory.tsx
@@ -22,7 +22,6 @@ interface BidHistoryProps {
   bids: BidType[];
   auction: AuctionType;
   user: UserType | undefined;
-  clock?: () => number;
 }
 
 /**
@@ -33,10 +32,9 @@ const BidHistory: Component<BidHistoryProps> = (props) => {
     isAuctionInProgress(props.auction)
   );
 
-  // Re-compute auction status based on clock changes.
+  // Re-compute auction status when relevant auction properties change
   createEffect(() => {
-    // We re-run this effect every time clock() changes.
-    props.clock && props.clock();
+    const { status, bids } = props.auction;
     setAuctionInProgress(isAuctionInProgress(props.auction));
   });
 

--- a/packages/auction-widget/src/hooks/useAuctionTimer.ts
+++ b/packages/auction-widget/src/hooks/useAuctionTimer.ts
@@ -1,0 +1,134 @@
+import { createSignal, createEffect, onCleanup, createMemo } from "solid-js";
+import { AuctionType } from "@encheres-immo/widget-client/types";
+import {
+  parseDate,
+  isAuctionNotStarted,
+  isAuctionInProgress,
+  isAuctionEnded,
+} from "../utils.jsx";
+
+type TimeRemaining = {
+  days: number;
+  hours: number;
+  minutes: number;
+  seconds: number;
+  formatted: string;
+  totalSeconds: number;
+};
+
+export function useAuctionTimer(auction: () => AuctionType) {
+  const [currentTime, setCurrentTime] = createSignal(Date.now());
+  const [timeRemaining, setTimeRemaining] = createSignal<TimeRemaining>({
+    days: 0,
+    hours: 0,
+    minutes: 0,
+    seconds: 0,
+    totalSeconds: 0,
+    formatted: "",
+  });
+
+  // These are derived from both auction status AND time calculations
+  const [isNotStarted, setIsNotStarted] = createSignal(false);
+  const [isInProgress, setIsInProgress] = createSignal(false);
+  const [isEnded, setIsEnded] = createSignal(false);
+
+  // Calculate time remaining to a target date
+  function calculateTimeRemaining(targetDate: number): TimeRemaining {
+    const totalSeconds = Math.max(0, (targetDate - currentTime()) / 1000);
+    const days = Math.floor(totalSeconds / (3600 * 24));
+    const hours = Math.floor((totalSeconds % (3600 * 24)) / 3600);
+    const minutes = Math.floor((totalSeconds % 3600) / 60);
+    const seconds = Math.floor(totalSeconds % 60);
+
+    return {
+      days,
+      hours,
+      minutes,
+      seconds,
+      totalSeconds,
+      formatted: `${days}j ${hours}h ${minutes}m ${seconds}s`,
+    };
+  }
+
+  // Memoize the actual auction data to reduce calculations
+  const auctionData = createMemo(() => auction());
+
+  // Track the last auction ID to detect when we're dealing with a new auction
+  const [lastAuctionId, setLastAuctionId] = createSignal("");
+
+  // Update timer and determine status based on both auction state and time
+  createEffect(() => {
+    const currentAuction = auctionData();
+    const now = currentTime();
+
+    // If auction ID changed, reset our state
+    if (currentAuction.id !== lastAuctionId()) {
+      setLastAuctionId(currentAuction.id);
+    }
+
+    // First, check the server-provided status
+    const serverNotStarted = isAuctionNotStarted(currentAuction);
+    const serverInProgress = isAuctionInProgress(currentAuction);
+    const serverEnded = isAuctionEnded(currentAuction);
+
+    // Then check time-based status
+    const startTimeReached = now >= currentAuction.startDate;
+    const endTimeReached = now >= currentAuction.endDate;
+
+    // Determine the effective status:
+    // 1. If server says it's ended, it's ended
+    // 2. Else if end time is reached, consider it ended locally
+    // 3. Else if server says it's in progress OR start time is reached, it's in progress
+    // 4. Otherwise it hasn't started yet
+    let effectiveNotStarted = false;
+    let effectiveInProgress = false;
+    let effectiveEnded = false;
+
+    if (serverEnded || endTimeReached) {
+      effectiveEnded = true;
+    } else if (serverInProgress || startTimeReached) {
+      effectiveInProgress = true;
+    } else {
+      effectiveNotStarted = true;
+    }
+
+    // Update our status signals
+    setIsNotStarted(effectiveNotStarted);
+    setIsInProgress(effectiveInProgress);
+    setIsEnded(effectiveEnded);
+
+    // Calculate appropriate time remaining based on status
+    if (effectiveEnded) {
+      setTimeRemaining({
+        days: 0,
+        hours: 0,
+        minutes: 0,
+        seconds: 0,
+        totalSeconds: 0,
+        formatted: "",
+      });
+    } else {
+      // If not started, countdown to start; if in progress, countdown to end
+      const targetDate = effectiveNotStarted
+        ? currentAuction.startDate
+        : currentAuction.endDate;
+
+      setTimeRemaining(calculateTimeRemaining(targetDate));
+    }
+  });
+
+  // Timer interval - update time every second
+  const timerInterval = setInterval(() => {
+    setCurrentTime(Date.now());
+  }, 1000);
+
+  // Clean up interval on component unmount
+  onCleanup(() => clearInterval(timerInterval));
+
+  return {
+    timeRemaining,
+    isNotStarted,
+    isInProgress,
+    isEnded,
+  };
+}

--- a/packages/auction-widget/src/utils.tsx
+++ b/packages/auction-widget/src/utils.tsx
@@ -1,22 +1,15 @@
 import { AuctionType, CurrencyType } from "@encheres-immo/widget-client/types";
 
 function isAuctionNotStarted(auction: AuctionType): boolean {
-  let now: number = new Date().setMilliseconds(0);
-  const startDate: number = new Date(auction.startDate).setMilliseconds(0);
-  return now < startDate;
+  return auction.status === "draft" || auction.status === "scheduled";
 }
 
 function isAuctionInProgress(auction: AuctionType): boolean {
-  let now: number = new Date().setMilliseconds(0);
-  const endDate: number = new Date(auction.endDate).setMilliseconds(0);
-  const startDate: number = new Date(auction.startDate).setMilliseconds(0);
-  return now <= endDate && now >= startDate;
+  return auction.status === "started";
 }
 
 function isAuctionEnded(auction: AuctionType): boolean {
-  let now: number = new Date().setMilliseconds(0);
-  const endDate: number = new Date(auction.endDate).setMilliseconds(0);
-  return now > endDate;
+  return auction.status === "completed" || auction.status === "cancelled";
 }
 
 /**
@@ -55,12 +48,11 @@ function formatDate(date: number): string {
  * Parse a string to check if it is a valid URL
  */
 function isValidUrl(url: string): boolean {
-    try { 
-      return Boolean(new URL(url)); 
-    }
-    catch(e){ 
-      return false;
-    }
+  try {
+    return Boolean(new URL(url));
+  } catch (e) {
+    return false;
+  }
 }
 
 export {

--- a/packages/auction-widget/tests/AuctionInfos.test.tsx
+++ b/packages/auction-widget/tests/AuctionInfos.test.tsx
@@ -17,13 +17,17 @@ afterEach(() => {
 
 describe("Countdown display", () => {
   test('displays "Démarre dans" when auction has not started', () => {
-    const auction = factoryAuction({ startDate: Date.now() + 10000 });
+    const auction = factoryAuction({
+      status: "scheduled",
+      startDate: Date.now() + 10000,
+    });
     render(() => <AuctionInfos auction={auction} user={user} />);
     expect(screen.getByText(/Démarre dans/i)).toBeInTheDocument();
   });
 
   test('displays "Se termine dans" when auction is in progress', () => {
     const auction = factoryAuction({
+      status: "started",
       startDate: Date.now() - 10000,
       endDate: Date.now() + 10000,
     });
@@ -33,6 +37,7 @@ describe("Countdown display", () => {
 
   test('displays "Vente terminée" when auction has ended', () => {
     const auction = factoryAuction({
+      status: "completed",
       startDate: Date.now() - 20000,
       endDate: Date.now() - 10000,
     });
@@ -44,7 +49,9 @@ describe("Countdown display", () => {
 describe("Auction details display", () => {
   test("displays auction start date correctly", () => {
     const startDate = Date.now() + 100000;
-    const auction = factoryAuction({ startDate });
+    const auction = factoryAuction({
+      startDate,
+    });
     render(() => <AuctionInfos auction={auction} user={user} />);
     const formattedStartDate = new Date(startDate).toLocaleString();
     expect(screen.getByText(formattedStartDate)).toBeInTheDocument();

--- a/packages/auction-widget/tests/BidHistory.test.tsx
+++ b/packages/auction-widget/tests/BidHistory.test.tsx
@@ -20,7 +20,10 @@ describe("Bids history", () => {
 
   beforeEach(() => {
     user = factoryUser();
-    auction = factoryAuction({ startDate: Date.now() - 1000 });
+    auction = factoryAuction({
+      status: "started",
+      startDate: Date.now() - 1000,
+    });
   });
 
   afterEach(() => {
@@ -60,6 +63,7 @@ describe("Bids history", () => {
   test("does not display bid history for non-participants in private auction", () => {
     const privateAuction = factoryAuction({
       isPrivate: true,
+      status: "started",
       startDate: Date.now() - 1000,
     });
     const bids = [factoryBid(), factoryBid()];
@@ -76,6 +80,7 @@ describe("Bids history", () => {
   test("displays bid history for participants in private auction", () => {
     const privateAuction = factoryAuction({
       isPrivate: true,
+      status: "started",
       startDate: Date.now() - 1000,
       registration: factoryRegistration(),
     });
@@ -120,7 +125,10 @@ describe("Bid component in bids history", () => {
 
   beforeEach(() => {
     user = factoryUser();
-    auction = factoryAuction({ startDate: Date.now() - 1000 });
+    auction = factoryAuction({
+      status: "started",
+      startDate: Date.now() - 1000,
+    });
   });
 
   afterEach(() => {

--- a/packages/auction-widget/tests/RegistrationStatus.test.tsx
+++ b/packages/auction-widget/tests/RegistrationStatus.test.tsx
@@ -23,6 +23,7 @@ describe("RegistrationStatus displays", () => {
     });
     auction = factoryAuction({
       registration: registration,
+      status: "started",
       startDate: Date.now() - 1000,
       endDate: Date.now() + 10000,
     });
@@ -41,6 +42,7 @@ describe("RegistrationStatus displays", () => {
     });
     auction = factoryAuction({
       registration: registration,
+      status: "scheduled",
       startDate: Date.now() + 10000,
       endDate: Date.now() + 20000,
     });
@@ -61,6 +63,7 @@ describe("RegistrationStatus displays", () => {
     });
     auction = factoryAuction({
       registration: registration,
+      status: "started",
       startDate: Date.now() - 1000,
       endDate: Date.now() + 10000,
     });
@@ -79,6 +82,7 @@ describe("RegistrationStatus displays", () => {
     });
     auction = factoryAuction({
       registration: registration,
+      status: "scheduled",
       startDate: Date.now() + 10000,
       endDate: Date.now() + 20000,
     });

--- a/packages/auction-widget/tests/test-utils.ts
+++ b/packages/auction-widget/tests/test-utils.ts
@@ -26,6 +26,7 @@ export function factoryAuction(
 ): AuctionType {
   const baseAuction: AuctionType = {
     id: "auction1",
+    status: "scheduled",
     startDate: Date.now() + 10000, // Starts in 10 seconds
     endDate: Date.now() + 20000, // Ends in 20 seconds
     startingPrice: 10000,

--- a/packages/widget-client/src/auctions.ts
+++ b/packages/widget-client/src/auctions.ts
@@ -138,6 +138,7 @@ function formatAuction(data: any): AuctionType {
 
   return {
     id: data.id,
+    status: data.status,
     startDate: data.startDate,
     endDate: data.endDate,
     startingPrice: data.startingPrice,

--- a/packages/widget-client/tests/bids.test.ts
+++ b/packages/widget-client/tests/bids.test.ts
@@ -15,6 +15,7 @@ describe("placeBidOnAuction", () => {
   it("should place a bid successfully", async () => {
     const auction: AuctionType = {
       id: "auction-123",
+      status: "started",
       startDate: 0,
       endDate: 0,
       startingPrice: 0,
@@ -85,6 +86,7 @@ describe("placeBidOnAuction", () => {
   it("should log 'Unauthorized' when response status is 401", async () => {
     const auction: AuctionType = {
       id: "auction-123",
+      status: "started",
       startDate: 0,
       endDate: 0,
       startingPrice: 0,
@@ -131,6 +133,7 @@ describe("placeBidOnAuction", () => {
   it("should handle validation errors with status 422", async () => {
     const auction: AuctionType = {
       id: "auction-123",
+      status: "started",
       startDate: 0,
       endDate: 0,
       startingPrice: 0,
@@ -168,6 +171,7 @@ describe("placeBidOnAuction", () => {
   it("should throw an error when fetch fails", async () => {
     const auction: AuctionType = {
       id: "auction-123",
+      status: "started",
       startDate: 0,
       endDate: 0,
       startingPrice: 0,

--- a/packages/widget-client/types.ts
+++ b/packages/widget-client/types.ts
@@ -4,6 +4,7 @@
  */
 export type AuctionType = {
   id: string;
+  status: "draft" | "scheduled" | "started" | "completed" | "cancelled";
   startDate: number;
   endDate: number;
   startingPrice: number;


### PR DESCRIPTION
Added `status` property to the `Auction` type and fixed a bug where auction information was not always updated dynamically—also, performance improvements.

## What does this change?

* `packages/auction-widget/src/App.tsx`: Added `status` field to the `auction` state and updated the `refreshAuction` function to handle the `endDate` update based on the new status.
* `packages/auction-widget/src/BidForm.tsx`: Removed the `clock` prop and updated the `createEffect` to react to changes in auction properties like `status`, `startDate`, and `endDate`.
* `packages/auction-widget/src/utils.tsx`: Updated utility functions `isAuctionNotStarted`, `isAuctionInProgress`, and `isAuctionEnded` to use the new `auction.status` field instead of date comparisons.

## How is it tested?

* `packages/auction-widget/tests/*`: Updated tests to use the new `status` field for auction.
* `packages/auction-widget/tests/BidForm.test.tsx`: Modified tests to ensure components react correctly to status changes. Added a new test to check label updates after a successful bid submission.
* `packages/auction-widget/tests/AuctionInfos.test.tsx`: Added a few tests to ensure components react correctly to status changes and new bids.

## How is it documented?

Expected behaviour.