### PR TITLE
feat(aution_widget): dynamic update on status and form

### DIFF
--- a/packages/auction-widget/src/RegistrationStatus.tsx
+++ b/packages/auction-widget/src/RegistrationStatus.tsx
@@ -1,6 +1,6 @@
-import { Component, Switch, Match } from "solid-js";
-import { isAuctionInProgress, isAuctionNotStarted } from "./utils.js";
+import { Component, Switch, Match, createMemo } from "solid-js";
 import { AuctionType } from "@encheres-immo/widget-client/types";
+import { useAuctionTimer } from "./hooks/useAuctionTimer.js";
 
 /**
  * Display a message depending on the user's registration status for the auction.
@@ -11,6 +11,12 @@ const RegistrationStatus: Component<{
 }> = (props) => {
   const { isLogged, auction } = props;
 
+  // Create a memo to track auction changes
+  const auctionData = createMemo(() => auction);
+
+  // Use the timer hook to properly handle time-based status changes
+  const { isNotStarted, isInProgress } = useAuctionTimer(auctionData);
+
   return (
     <Switch>
       <Match
@@ -19,7 +25,7 @@ const RegistrationStatus: Component<{
           auction.registration &&
           auction.registration.isRegistrationAccepted &&
           !auction.registration.isParticipant &&
-          isAuctionInProgress(auction)
+          isInProgress()
         }
       >
         <p class="auction-widget-note">
@@ -32,7 +38,7 @@ const RegistrationStatus: Component<{
           auction.registration &&
           auction.registration.isRegistrationAccepted &&
           !auction.registration.isParticipant &&
-          isAuctionNotStarted(auction)
+          isNotStarted()
         }
       >
         <p class="auction-widget-note">
@@ -45,7 +51,7 @@ const RegistrationStatus: Component<{
           isLogged() &&
           auction.registration &&
           auction.registration.isRegistrationAccepted === true &&
-          isAuctionNotStarted(auction)
+          isNotStarted()
         }
       >
         <p class="auction-widget-note">

--- a/packages/auction-widget/tests/RegistrationStatus.test.tsx
+++ b/packages/auction-widget/tests/RegistrationStatus.test.tsx
@@ -1,5 +1,5 @@
-import { test, expect, describe, beforeEach, afterEach } from "vitest";
-import { render, screen, cleanup } from "@solidjs/testing-library";
+import { test, expect, describe, beforeEach, afterEach, vi } from "vitest";
+import { render, screen, cleanup, waitFor } from "@solidjs/testing-library";
 import RegistrationStatus from "../src/RegistrationStatus.js";
 import { AuctionType } from "@encheres-immo/widget-client/types";
 import { factoryAuction, factoryRegistration } from "./test-utils.js";
@@ -128,5 +128,143 @@ describe("RegistrationStatus displays", () => {
         /Votre demande de participation a été transmise à l'agent responsable du bien/i
       )
     ).toBeInTheDocument();
+  });
+});
+
+describe("Dynamic RegistrationStatus updates", () => {
+  beforeEach(() => {
+    // Mock Date.now to have consistent behavior
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2023, 0, 1, 12, 0, 0)); // Noon on January 1st, 2023
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    cleanup();
+  });
+
+  test("updates observer message when auction transitions from scheduled to started", async () => {
+    // Create an auction scheduled to start in 5 seconds
+    const startTime = Date.now() + 5000;
+    const endTime = Date.now() + 60000;
+
+    const registration = factoryRegistration({
+      isRegistrationAccepted: true,
+      isParticipant: false, // Observer
+    });
+
+    const auction = factoryAuction({
+      status: "scheduled",
+      startDate: startTime,
+      endDate: endTime,
+      registration: registration,
+    });
+
+    render(() => (
+      <RegistrationStatus isLogged={() => true} auction={auction} />
+    ));
+
+    // Initially should show the "waiting for auction" observer message
+    expect(
+      screen.getByText(
+        /Votre demande d'observation pour cette vente a été acceptée/i
+      )
+    ).toBeInTheDocument();
+
+    // Advance time past the start date
+    vi.advanceTimersByTime(10000); // 10 seconds
+
+    // Message should change to the "auction in progress" observer message
+    await waitFor(() => {
+      expect(
+        screen.getByText(/Vous êtes observateur pour cette vente/i)
+      ).toBeInTheDocument();
+    });
+  });
+
+  test("updates participant message when auction transitions from scheduled to started", async () => {
+    // Create an auction scheduled to start in 5 seconds
+    const startTime = Date.now() + 5000;
+    const endTime = Date.now() + 60000;
+
+    const registration = factoryRegistration({
+      isRegistrationAccepted: true,
+      isParticipant: true, // Participant
+    });
+
+    const auction = factoryAuction({
+      status: "scheduled",
+      startDate: startTime,
+      endDate: endTime,
+      registration: registration,
+    });
+
+    const { container } = render(() => (
+      <RegistrationStatus isLogged={() => true} auction={auction} />
+    ));
+
+    // Initially should show the "waiting for auction" participant message
+    expect(
+      screen.getByText(
+        /Votre demande de participation pour cette vente a été acceptée/i
+      )
+    ).toBeInTheDocument();
+
+    // Advance time past the start date
+    vi.advanceTimersByTime(10000); // 10 seconds
+
+    // For participants, no message should be shown once the auction has started
+    await waitFor(() => {
+      const notes = container.querySelectorAll(".auction-widget-note");
+      expect(notes.length).toBe(0);
+    });
+  });
+
+  test("handles complete auction lifecycle for observer", async () => {
+    // Create an auction scheduled to start in 5 seconds and end in 15 seconds
+    const startTime = Date.now() + 5000; // Starts in 5 seconds
+    const endTime = Date.now() + 15000; // Ends in 15 seconds
+
+    const registration = factoryRegistration({
+      isRegistrationAccepted: true,
+      isParticipant: false, // Observer
+    });
+
+    const auction = factoryAuction({
+      status: "scheduled",
+      startDate: startTime,
+      endDate: endTime,
+      registration: registration,
+    });
+
+    const { container } = render(() => (
+      <RegistrationStatus isLogged={() => true} auction={auction} />
+    ));
+
+    // Initially should show the waiting message for observers
+    expect(
+      screen.getByText(
+        /Votre demande d'observation pour cette vente a été acceptée/i
+      )
+    ).toBeInTheDocument();
+
+    // Advance time to just after start
+    vi.advanceTimersByTime(7000); // 7 seconds
+
+    // Should show in-progress message for observers
+    await waitFor(() => {
+      expect(
+        screen.getByText(/Vous êtes observateur pour cette vente/i)
+      ).toBeInTheDocument();
+    });
+
+    // Advance time to after end
+    vi.advanceTimersByTime(10000); // Another 10 seconds (total 17 seconds)
+
+    // For auction that has ended, no message should be shown
+    await waitFor(() => {
+      const notes = container.querySelectorAll(".auction-widget-note");
+      expect(notes.length).toBe(0);
+    });
   });
 });

--- a/packages/auction-widget/vitest.config.ts
+++ b/packages/auction-widget/vitest.config.ts
@@ -6,4 +6,7 @@ export default defineConfig({
   resolve: {
     conditions: ["development", "browser"],
   },
+  test: {
+    testTimeout: 1000,
+  },
 });


### PR DESCRIPTION
Apply #65 to `BidForm` & `RegistrationStatus`, but causes #69 .

## What does this change?

* `packages/auction-widget/src/BidForm.tsx`: Added `useAuctionTimer` hook to handle time-based status changes and replaced the `isAuctionInProgress` signal with the new hook.
* `packages/auction-widget/src/RegistrationStatus.tsx`: Added `useAuctionTimer` hook to handle time-based status changes and replaced `isAuctionInProgress` and `isAuctionNotStarted` with the new hook.

## How is it tested?

* `packages/auction-widget/tests/BidForm.test.tsx`: Added tests for dynamic bid form updates to ensure the form appears and disappears based on auction start and end times.
* `packages/auction-widget/tests/RegistrationStatus.test.tsx`: Added tests for dynamic registration status updates to ensure messages update correctly based on auction state transitions.

## How is it documented?

Expected behaviour.